### PR TITLE
Fix reporters not working

### DIFF
--- a/asciidoc_linter/reporter.py
+++ b/asciidoc_linter/reporter.py
@@ -50,7 +50,7 @@ class ConsoleReporter(Reporter):
             
         output = []
         for error in report.errors:
-            location = f"\033[36mline {error.line}\033[0m"
+            location = f"\033[36mline {error.position.line}\033[0m"
             if error.file:
                 location = f"\033[36m{error.file}:{location}\033[0m"
             


### PR DESCRIPTION
Fixes #3

Update `ConsoleReporter` class to correctly handle findings and display their positions.

* Change `ConsoleReporter` class in `asciidoc_linter/reporter.py` to use `error.position.line` instead of `error.line` to correctly access the line number.
* Ensure `ConsoleReporter` class correctly handles the `position` attribute of `Finding` instances.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/docToolchain/asciidoc-linter/pull/4?shareId=2206fcd4-db91-4373-9c43-c7ffb15ff611).