### PR TITLE
Re-format all AsciiDoc files due to good practices

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,16 +5,18 @@
 :source-highlighter: rouge
 :experimental:
 
-image:https://img.shields.io/badge/license-MIT-blue.svg[License: MIT, link=https://opensource.org/licenses/MIT]
+image:https://img.shields.io/badge/license-MIT-blue.svg[License: MIT,link=https://opensource.org/licenses/MIT]
 image:https://img.shields.io/badge/python-3.8+-blue.svg[Python Version]
 image:https://img.shields.io/badge/test--coverage-95%25-green.svg[Test Coverage]
 image:https://img.shields.io/badge/tests-97%25-green.svg[Test Success Rate]
 
-A Python-based linter for AsciiDoc files that helps maintain consistent documentation quality and style. Part of the docToolchain project.
+A Python-based linter for AsciiDoc files that helps maintain consistent documentation quality and style.
+Part of the docToolchain project.
 
 == About
 
-AsciiDoc Linter is a command-line tool that checks your AsciiDoc files for common issues and style violations. It helps maintain consistent documentation by enforcing rules for heading structure, formatting, whitespace, and image usage.
+AsciiDoc Linter is a command-line tool that checks your AsciiDoc files for common issues and style violations.
+It helps maintain consistent documentation by enforcing rules for heading structure, formatting, whitespace, and image usage.
 
 [NOTE]
 ====
@@ -209,7 +211,9 @@ asciidoc-linter/
 
 == Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
+Contributions are welcome!
+Please feel free to submit a Pull Request.
+For major changes, please open an issue first to discuss what you would like to change.
 
 === Development Guidelines
 

--- a/docs/arc42/01_introduction_and_goals.adoc
+++ b/docs/arc42/01_introduction_and_goals.adoc
@@ -4,7 +4,8 @@
 
 === Requirements Overview
 
-The AsciiDoc Linter is a tool designed to ensure consistent formatting and structure in AsciiDoc documents. It helps teams maintain high-quality documentation by enforcing style rules and best practices.
+The AsciiDoc Linter is a tool designed to ensure consistent formatting and structure in AsciiDoc documents.
+It helps teams maintain high-quality documentation by enforcing style rules and best practices.
 
 Key requirements include:
 

--- a/docs/arc42/08_concepts.adoc
+++ b/docs/arc42/08_concepts.adoc
@@ -47,16 +47,19 @@ package "Domain Model" {
 === Security Concepts
 
 ==== Authentication and Authorization
+
 * Package distribution secured via PyPI authentication
 * Configuration files with restricted access
 * Signed releases with GPG keys
 
 ==== Input Validation
+
 * Strict content validation
 * Safe file handling
 * Memory usage limits
 
 ==== Output Sanitization
+
 * Escaped error messages
 * Safe file paths handling
 * Controlled error reporting

--- a/docs/arc42/09_architecture_decisions.adoc
+++ b/docs/arc42/09_architecture_decisions.adoc
@@ -6,22 +6,29 @@ This chapter contains all architecture decisions for the AsciiDoc Linter project
 Each decision is documented in a separate file and included here.
 
 === ADR 1: Rule Base Class Design
+
 include::decisions/ADR-001-rule-base-class.adoc[leveloffset=+2]
 
 === ADR 2: Finding Data Structure
+
 include::decisions/ADR-002-finding-data-structure.adoc[leveloffset=+2]
 
 === ADR 3: Rule Implementation Strategy
+
 include::decisions/ADR-003-rule-implementation-strategy.adoc[leveloffset=+2]
 
 === ADR 4: Test Strategy
+
 include::decisions/ADR-004-test-strategy.adoc[leveloffset=+2]
 
 === ADR 5: Table Processing Strategy
+
 include::decisions/ADR-005-table-processing-strategy.adoc[leveloffset=+2]
 
 === ADR 6: Severity Standardization
+
 include::decisions/ADR-006-severity-standardization.adoc[leveloffset=+2]
 
 === ADR 7: Rule Registry Enhancement
+
 include::decisions/ADR-007-rule-registry-enhancement.adoc[leveloffset=+2]

--- a/docs/arc42/10_quality_requirements.adoc
+++ b/docs/arc42/10_quality_requirements.adoc
@@ -200,21 +200,25 @@ SHOW_LEGEND()
 === Quality Metrics
 
 ==== Test Quality
+
 * Test Coverage: >90% for all modules
 * Test Success Rate: >95%
 * Edge Case Coverage: All identified edge cases have tests
 
 ==== Code Quality
+
 * Maintainability Index: >80
 * Cyclomatic Complexity: <10 per method
 * Documentation Coverage: >80%
 
 ==== Performance
+
 * Processing Speed: <1ms per line
 * Memory Usage: <100MB
 * Table Processing: <20ms per table
 
 ==== Reliability
+
 * False Positive Rate: <1%
 * Error Recovery: 100% of known error cases
 * Plugin Stability: No impact on core functionality

--- a/docs/arc42/11_technical_risks.adoc
+++ b/docs/arc42/11_technical_risks.adoc
@@ -5,16 +5,19 @@
 === Current Issues (December 2024)
 
 ==== Test Failures
+
 * 3 failed tests in table processing
 * Issues with cell extraction and list detection
 * Impact on table validation reliability
 
 ==== Coverage Gaps
+
 * rules.py: 0% coverage
 * reporter.py: 85% coverage
 * block_rules.py: 89% coverage
 
 ==== Implementation Issues
+
 * Inconsistent severity case handling
 * Missing rule_id attribute in base class
 * Table content validation problems
@@ -229,16 +232,19 @@ SHOW_LEGEND()
 === Mitigation Strategy
 
 ==== Phase 1: Critical Issues (1-2 weeks)
+
 1. Fix table processing
 2. Add missing tests
 3. Standardize severity handling
 
 ==== Phase 2: Important Improvements (2-3 weeks)
+
 1. Improve documentation
 2. Enhance error handling
 3. Add configuration options
 
 ==== Phase 3: Long-term Stability (3-4 weeks)
+
 1. Performance optimization
 2. Memory management
 3. Plugin architecture improvements

--- a/docs/arc42/decisions/ADR-001-rule-base-class.adoc
+++ b/docs/arc42/decisions/ADR-001-rule-base-class.adoc
@@ -1,17 +1,21 @@
-# ADR-001-rule-base-class.adoc - Rule Base Class Design Decision
+= ADR-001-rule-base-class.adoc - Rule Base Class Design Decision
 
 == ADR 1: Rule Base Class Design
 
 === Status
+
 Accepted
 
 === Context
+
 We need a flexible and extensible way to implement different linting rules for AsciiDoc documents.
 
 === Decision
+
 We will use an abstract base class `Rule` with a defined interface that all concrete rules must implement.
 
 === Consequences
+
 * *Positive*
 ** Consistent interface for all rules
 ** Easy to add new rules

--- a/docs/arc42/decisions/ADR-002-finding-data-structure.adoc
+++ b/docs/arc42/decisions/ADR-002-finding-data-structure.adoc
@@ -1,17 +1,21 @@
-# ADR-002-finding-data-structure.adoc - Finding Data Structure Decision
+= ADR-002-finding-data-structure.adoc - Finding Data Structure Decision
 
 == ADR 2: Finding Data Structure
 
 === Status
+
 Accepted
 
 === Context
+
 Rule violations need to be reported in a consistent and informative way.
 
 === Decision
+
 We will use a `Finding` data class with fields for message, severity, position, rule ID, and context.
 
 === Consequences
+
 * *Positive*
 ** Structured error reporting
 ** Rich context for violations

--- a/docs/arc42/decisions/ADR-003-rule-implementation-strategy.adoc
+++ b/docs/arc42/decisions/ADR-003-rule-implementation-strategy.adoc
@@ -1,17 +1,21 @@
-# ADR-003-rule-implementation-strategy.adoc - Rule Implementation Strategy Decision
+= ADR-003-rule-implementation-strategy.adoc - Rule Implementation Strategy Decision
 
 == ADR 3: Rule Implementation Strategy
 
 === Status
+
 Accepted
 
 === Context
+
 Rules need to process AsciiDoc content and identify violations efficiently.
 
 === Decision
+
 Each rule will process the content line by line, using regular expressions for pattern matching.
 
 === Consequences
+
 * *Positive*
 ** Simple implementation
 ** Good performance for most cases

--- a/docs/arc42/decisions/ADR-004-test-strategy.adoc
+++ b/docs/arc42/decisions/ADR-004-test-strategy.adoc
@@ -1,17 +1,21 @@
-# ADR-004-test-strategy.adoc - Test Strategy Decision
+= ADR-004-test-strategy.adoc - Test Strategy Decision
 
 == ADR 4: Test Strategy
 
 === Status
+
 Accepted
 
 === Context
+
 Rules need to be thoroughly tested to ensure reliable operation.
 
 === Decision
+
 Each rule will have its own test class with multiple test methods covering various scenarios.
 
 === Consequences
+
 * *Positive*
 ** High test coverage
 ** Clear test organization

--- a/docs/arc42/decisions/ADR-005-table-processing-strategy.adoc
+++ b/docs/arc42/decisions/ADR-005-table-processing-strategy.adoc
@@ -1,43 +1,41 @@
-# ADR-005-table-processing-strategy.adoc - Table Processing Strategy Decision
+= ADR-005-table-processing-strategy.adoc - Table Processing Strategy Decision
 
 == ADR 5: Table Processing Strategy
 
 === Status
+
 Proposed
 
 === Context
+
 Table processing in AsciiDoc documents requires complex parsing and validation:
-* Tables can contain various content types (text, lists, blocks)
-* Cell extraction needs to handle multi-line content
-* Column counting must be reliable
-* List detection in cells must be accurate
+* Tables can contain various content types (text, lists, blocks) * Cell extraction needs to handle multi-line content * Column counting must be reliable * List detection in cells must be accurate
 
 Current implementation has issues:
-* Cell extraction produces incorrect results
-* List detection generates false positives
-* Column counting is unreliable
+* Cell extraction produces incorrect results * List detection generates false positives * Column counting is unreliable
 
 === Decision
+
 We will implement a new table processing strategy:
 
 1. *Two-Pass Parsing*
-   * First pass: Identify table boundaries and structure
-   * Second pass: Extract and validate cell content
+* First pass: Identify table boundaries and structure
+* Second pass: Extract and validate cell content
 
 2. *Cell Content Model*
-   * Create a dedicated TableCell class
-   * Track content type (text, list, block)
-   * Maintain line number information
+* Create a dedicated TableCell class
+* Track content type (text, list, block)
+* Maintain line number information
 
 3. *List Detection*
-   * Use state machine for list recognition
-   * Track list context across cell boundaries
-   * Validate list markers against AsciiDoc spec
+* Use state machine for list recognition
+* Track list context across cell boundaries
+* Validate list markers against AsciiDoc spec
 
 4. *Column Management*
-   * Count columns based on header row
-   * Validate all rows against header
-   * Handle empty cells explicitly
+* Count columns based on header row
+* Validate all rows against header
+* Handle empty cells explicitly
 
 === Technical Details
 
@@ -90,29 +88,26 @@ class TableProcessor:
 === Implementation Plan
 
 1. Phase 1: Core Structure
-   * Implement TableCell and TableRow classes
-   * Basic two-pass parsing
-   * Unit tests for basic functionality
+* Implement TableCell and TableRow classes
+* Basic two-pass parsing
+* Unit tests for basic functionality
 
 2. Phase 2: Content Processing
-   * List detection state machine
-   * Content type recognition
-   * Error context collection
+* List detection state machine
+* Content type recognition
+* Error context collection
 
 3. Phase 3: Validation
-   * Column counting
-   * Structure validation
-   * Comprehensive test suite
+* Column counting
+* Structure validation
+* Comprehensive test suite
 
 === Validation
 
 Success criteria:
-* All current table-related tests pass
-* Cell extraction matches expected results
-* List detection has no false positives
-* Column counting is accurate
-* Memory usage remains within limits
+* All current table-related tests pass * Cell extraction matches expected results * List detection has no false positives * Column counting is accurate * Memory usage remains within limits
 
 === Related Diagrams
+
 image::../images/decisions/table-processing-class-diagram.png[Table Processing Class Diagram]
 image::../images/decisions/table-processing-sequence.png[Table Processing Sequence]

--- a/docs/arc42/decisions/ADR-006-severity-standardization.adoc
+++ b/docs/arc42/decisions/ADR-006-severity-standardization.adoc
@@ -1,35 +1,37 @@
-# ADR-006-severity-standardization.adoc - Severity Standardization Decision
+= ADR-006-severity-standardization.adoc - Severity Standardization Decision
 
 == ADR 6: Severity Standardization
 
 === Status
+
 Proposed
 
 === Context
+
 Current implementation has inconsistent severity level handling:
-* Mixed case usage (ERROR vs error)
-* Inconsistent severity levels across rules
-* No clear guidelines for severity assignment
+* Mixed case usage (ERROR vs error) * Inconsistent severity levels across rules * No clear guidelines for severity assignment
 
 === Decision
+
 We will standardize severity handling:
 
 1. *Severity Levels*
-   * ERROR: Issues that must be fixed
-   * WARNING: Issues that should be reviewed
-   * INFO: Suggestions for improvement
+* ERROR: Issues that must be fixed
+* WARNING: Issues that should be reviewed
+* INFO: Suggestions for improvement
 
 2. *Implementation*
-   * Use lowercase for internal representation
-   * Provide case-sensitive display methods
-   * Add severity level documentation
+* Use lowercase for internal representation
+* Provide case-sensitive display methods
+* Add severity level documentation
 
 3. *Migration*
-   * Update all existing rules
-   * Add validation in base class
-   * Update tests to use new standard
+* Update all existing rules
+* Add validation in base class
+* Update tests to use new standard
 
 === Consequences
+
 * *Positive*
 ** Consistent severity handling
 ** Clear guidelines for new rules
@@ -39,4 +41,5 @@ We will standardize severity handling:
 ** Potential backward compatibility issues
 
 === Related Diagrams
+
 image::../images/decisions/severity-state-diagram.png[Severity State Diagram]

--- a/docs/arc42/decisions/ADR-007-rule-registry-enhancement.adoc
+++ b/docs/arc42/decisions/ADR-007-rule-registry-enhancement.adoc
@@ -1,36 +1,37 @@
-# ADR-007-rule-registry-enhancement.adoc - Rule Registry Enhancement Decision
+= ADR-007-rule-registry-enhancement.adoc - Rule Registry Enhancement Decision
 
 == ADR 7: Rule Registry Enhancement
 
 === Status
+
 Proposed
 
 === Context
+
 Current rule registry implementation lacks:
-* Test coverage
-* Clear registration mechanism
-* Version handling
-* Rule dependency management
+* Test coverage * Clear registration mechanism * Version handling * Rule dependency management
 
 === Decision
+
 We will enhance the rule registry:
 
 1. *Registration*
-   * Add explicit registration decorator
-   * Support rule dependencies
-   * Add version information
+* Add explicit registration decorator
+* Support rule dependencies
+* Add version information
 
 2. *Management*
-   * Add rule enabling/disabling
-   * Support rule groups
-   * Add configuration validation
+* Add rule enabling/disabling
+* Support rule groups
+* Add configuration validation
 
 3. *Testing*
-   * Add comprehensive test suite
-   * Test all registration scenarios
-   * Test configuration handling
+* Add comprehensive test suite
+* Test all registration scenarios
+* Test configuration handling
 
 === Consequences
+
 * *Positive*
 ** Better rule management
 ** Clear registration process
@@ -40,5 +41,6 @@ We will enhance the rule registry:
 ** Additional maintenance overhead
 
 === Related Diagrams
+
 image::../images/decisions/rule-registry-components.png[Rule Registry Components]
 image::../images/decisions/rule-registration-flow.png[Rule Registration Flow]

--- a/docs/block_rules.adoc
+++ b/docs/block_rules.adoc
@@ -7,12 +7,16 @@
 == BLOCK001: Unterminated Block Check
 
 === Purpose
-This rule checks for blocks in AsciiDoc files that are not properly terminated. It helps prevent incomplete or malformed block structures that could lead to incorrect rendering.
+
+This rule checks for blocks in AsciiDoc files that are not properly terminated.
+It helps prevent incomplete or malformed block structures that could lead to incorrect rendering.
 
 === Severity
+
 ERROR
 
 === Supported Block Types
+
 * Listing blocks (`----`)
 * Example blocks (`====`)
 * Sidebar blocks (`****`)
@@ -25,6 +29,7 @@ ERROR
 === Examples
 
 ==== Valid Block Structure
+
 [source,asciidoc]
 ----
 .Example Title
@@ -35,6 +40,7 @@ It has proper opening and closing delimiters.
 ----
 
 ==== Invalid Block Structure
+
 [source,asciidoc]
 ----
 .Example Title
@@ -44,6 +50,7 @@ More content...
 ----
 
 === Error Messages
+
 * "Unterminated listing block starting"
 * "Unterminated example block starting"
 * "Unterminated sidebar block starting"
@@ -52,55 +59,70 @@ More content...
 == BLOCK002: Block Spacing Check
 
 === Purpose
-This rule ensures proper spacing around blocks by checking for blank lines before and after block structures. Proper spacing improves readability and follows AsciiDoc best practices.
+
+This rule ensures proper spacing around blocks by checking for blank lines before and after block structures.
+Proper spacing improves readability and follows AsciiDoc best practices.
 
 === Severity
+
 WARNING
 
 === Rules
+
 1. A blank line should precede a block (except when it follows a heading)
 2. A blank line should follow a block (except when it's followed by a heading)
 
 === Examples
 
 ==== Valid Block Spacing
+
 [source,asciidoc]
 ----
 Some text before the block.
 
 ----
+
 Block content
+
 ----
 
 More text after the block.
 ----
 
 ==== Invalid Block Spacing
+
 [source,asciidoc]
 ----
 Some text before the block.
 ----
+
 Block content
+
 ----
 More text after the block.
 ----
 
 === Error Messages
+
 * "Block should be preceded by a blank line"
 * "Block should be followed by a blank line"
 
 === Special Cases
+
 * Blocks immediately following headings don't require a preceding blank line
 * Blocks immediately followed by headings don't require a following blank line
 
 == Implementation Details
 
 === Rule Classes
+
 * `UnterminatedBlockRule`: Implements BLOCK001
 * `BlockSpacingRule`: Implements BLOCK002
 
 === Configuration
-Currently, these rules are not configurable. Future versions may allow:
+
+Currently, these rules are not configurable.
+Future versions may allow:
 
 * Custom block types
 * Adjustable severity levels
@@ -108,6 +130,7 @@ Currently, these rules are not configurable. Future versions may allow:
 * Custom spacing requirements
 
 === Performance Considerations
+
 * Both rules process files line by line
 * Block tracking uses minimal memory
 * Processing time is O(n) where n is the number of lines

--- a/docs/canvas/architecture-canvas.adoc
+++ b/docs/canvas/architecture-canvas.adoc
@@ -37,7 +37,7 @@
 [cols="25,25,25,25"]
 |===
 
-a| 
+a|
 *Value Proposition*
 
 * Automated quality assurance for AsciiDoc documentation

--- a/docs/implementation_plan.adoc
+++ b/docs/implementation_plan.adoc
@@ -11,6 +11,7 @@
 == Current Status Analysis
 
 === Test Infrastructure Status (Updated December 2024)
+
 * ✅ Coverage Tools working
 ** Coverage report generation fixed
 ** HTML reports generating correctly
@@ -27,29 +28,34 @@
 === Module Coverage Status
 
 ==== Perfect Coverage (100%)
+
 * ✅ image_rules.py
 * ✅ parser.py
 * ✅ __init__.py files
 * ✅ rules.py (NEW)
 
 ==== Very Good Coverage (95-99%)
+
 * ✅ whitespace_rules.py (98%)
 * ✅ cli.py (98%)
 * ✅ linter.py (97%)
 * ✅ table_rules.py (94%)
 
 ==== Good Coverage (85-94%)
+
 * ⚠️ block_rules.py (89%)
 * ⚠️ heading_rules.py (93%)
 * ⚠️ reporter.py (85%)
 * ✅ base.py (92%)
 
 ==== Critical Coverage Issues
+
 * ❌ concrete_rules.py (0%)
 
 === Fixed Issues
 
 ==== Core Architecture Issues
+
 * ✅ Severity Implementation
 ** Fixed case handling (standardized on lowercase)
 ** Enhanced string comparison
@@ -59,6 +65,7 @@
 ** 1 failing test
 
 ==== Table Processing Issues
+
 * ✅ Table Content Rule
 ** Fixed cell extraction with regex
 ** Fixed list detection
@@ -68,6 +75,7 @@
 ** Fixed empty table handling
 
 ==== Rules Module Issues (NEW)
+
 * ✅ Import structure fixed
 * ✅ Test coverage improved
 * ✅ Documentation updated
@@ -77,6 +85,7 @@
 === Phase 1: Fix Failed Tests (1-2 days)
 
 ==== Step 1: Core Architecture Fixes (Priority: High)
+
 * ✅ Fix Severity implementation:
 ** ✅ Standardize on lowercase values
 ** ✅ Update all rule implementations
@@ -90,6 +99,7 @@
 ** Update all rule implementations
 
 ==== Step 2: Table Processing Fixes (Priority: High)
+
 * ✅ Fix cell extraction:
 ** ✅ Review and fix cell counting
 ** ✅ Fix list detection
@@ -104,6 +114,7 @@
 === Phase 2: Coverage Improvements (2-3 days)
 
 ==== Step 1: Critical Coverage (Priority: High)
+
 * ✅ Fix rules.py coverage:
 ** ✅ Add missing tests
 ** ✅ Review and update implementation
@@ -115,6 +126,7 @@
 ** Create test_concrete_rules.py
 
 ==== Step 2: Module Coverage (Priority: Medium)
+
 * Improve reporter.py coverage:
 ** Add tests for error handling
 ** Cover edge cases
@@ -128,6 +140,7 @@
 === Phase 3: Quality Improvements (2-3 days)
 
 ==== Step 1: Code Quality (Priority: Medium)
+
 * Add type hints:
 ** Focus on public interfaces
 ** Add mypy configuration
@@ -139,6 +152,7 @@
 ** Update error handling
 
 ==== Step 2: Documentation (Priority: Medium)
+
 * Update documentation:
 ** Review and update README
 ** Update rule documentation
@@ -211,11 +225,13 @@ In Progress for concrete_rules.py
 == Quality Gates
 
 === For Test Coverage
+
 * No module below 90% coverage
 * Core modules must have >95% coverage
 * All public methods must have tests
 
 === For Implementation
+
 * All tests must pass
 * Type hints for public interfaces
 * Documentation must be current

--- a/docs/manual/introduction.adoc
+++ b/docs/manual/introduction.adoc
@@ -3,7 +3,8 @@
 
 == About the Project
 
-AsciiDoc Linter is a Python-based tool designed to help maintain high-quality AsciiDoc documentation. It checks your AsciiDoc files for common issues and style violations, helping teams maintain consistent documentation standards.
+AsciiDoc Linter is a Python-based tool designed to help maintain high-quality AsciiDoc documentation.
+It checks your AsciiDoc files for common issues and style violations, helping teams maintain consistent documentation standards.
 
 As part of the docToolchain project (https://doctoolchain.org), it integrates well with existing documentation workflows.
 
@@ -65,7 +66,8 @@ As part of the docToolchain project (https://doctoolchain.org), it integrates we
 
 [NOTE]
 ====
-Direct installation via pip is planned for future releases. Currently, installation is done via git clone.
+Direct installation via pip is planned for future releases.
+Currently, installation is done via git clone.
 ====
 
 [source,bash]

--- a/docs/manual/rules.adoc
+++ b/docs/manual/rules.adoc
@@ -9,7 +9,8 @@ Ensures proper heading level incrementation (no skipped levels).
 
 ==== Description
 
-This rule checks that heading levels are not skipped. For example, you cannot go from a level 1 heading (=) directly to a level 3 heading (===) without having a level 2 heading (==) in between.
+This rule checks that heading levels are not skipped.
+For example, you cannot go from a level 1 heading (=) directly to a level 3 heading (===) without having a level 2 heading (==) in between.
 
 ==== Examples
 
@@ -40,8 +41,7 @@ Ensures proper heading format (spacing and capitalization).
 ==== Description
 
 This rule checks two aspects of heading format:
-1. There must be a space after the = characters
-2. The heading text should start with an uppercase letter
+1. There must be a space after the = characters 2. The heading text should start with an uppercase letter
 
 ==== Examples
 
@@ -66,7 +66,8 @@ Ensures document has only one top-level heading.
 
 ==== Description
 
-This rule checks that there is only one level 1 heading (=) in the document. Multiple top-level headings can indicate structural problems or accidentally split documents.
+This rule checks that there is only one level 1 heading (=) in the document.
+Multiple top-level headings can indicate structural problems or accidentally split documents.
 
 ==== Examples
 
@@ -97,7 +98,8 @@ Checks for blocks that are not properly terminated.
 
 ==== Description
 
-This rule ensures that all block delimiters are properly paired. Each opening delimiter must have a matching closing delimiter.
+This rule ensures that all block delimiters are properly paired.
+Each opening delimiter must have a matching closing delimiter.
 
 ==== Supported Block Types
 
@@ -117,8 +119,10 @@ This rule ensures that all block delimiters are properly paired. Each opening de
 ----
 [source,python]
 ----
+
 def hello():
-    print("Hello, World!")
+print("Hello, World!")
+
 ----
 
 .Example Block
@@ -132,8 +136,9 @@ Some example content
 ----
 [source,python]
 ----
+
 def hello():
-    print("Hello, World!")
+print("Hello, World!")
 // Error: Missing closing ----
 
 .Example Block
@@ -155,6 +160,7 @@ This rule checks that blocks are properly separated from surrounding content wit
 .Valid Block Spacing
 [source,asciidoc]
 ----
+
 Some text before the block.
 
 ----
@@ -162,14 +168,16 @@ Block content
 ----
 
 Some text after the block.
+
 ----
 
 .Invalid Block Spacing
 [source,asciidoc]
 ----
+
 Some text before the block.
-----  // Warning: No blank line before block
-Block content
+---- // Warning: No blank line before block Block content
+
 ----
 Some text after the block.  // Warning: No blank line after block
 ----
@@ -229,10 +237,7 @@ Verifies image attributes and file references.
 ==== Description
 
 This rule checks:
-1. All images have alt text
-2. Referenced local images exist
-3. Block images have titles
-4. Image attributes are properly formatted
+1. All images have alt text 2. Referenced local images exist 3. Block images have titles 4. Image attributes are properly formatted
 
 ==== Examples
 
@@ -268,21 +273,15 @@ image::missing.png[Missing Image]
 === TABLE001: Table Formatting (Planned)
 
 Will check table formatting consistency:
-* Column alignment
-* Header row presence
-* Cell content formatting
+* Column alignment * Header row presence * Cell content formatting
 
 === LINK001: Link Verification (Planned)
 
 Will verify:
-* Internal cross-references
-* External link validity
-* Anchor definitions
+* Internal cross-references * External link validity * Anchor definitions
 
 === FMT001: Format Consistency (Planned)
 
 Will check:
-* Consistent emphasis style
-* List formatting
-* Admonition usage
+* Consistent emphasis style * List formatting * Admonition usage
 

--- a/docs/manual/testing.adoc
+++ b/docs/manual/testing.adoc
@@ -19,18 +19,21 @@ The testing strategy for the AsciiDoc Linter aims to:
 === Test Levels
 
 ==== Unit Tests
+
 * Test individual rules in isolation
 * Verify rule logic and error detection
 * Cover edge cases and special scenarios
 * Test configuration options
 
 ==== Integration Tests
+
 * Test interaction between parser and rules
 * Verify correct document processing
 * Test CLI interface and options
 * Test reporter output formats
 
 ==== System Tests
+
 * End-to-end testing of the linter
 * Test with real AsciiDoc documents
 * Verify correct error reporting
@@ -122,12 +125,14 @@ def test_integration_pattern(self):
 === Test Data Management
 
 ==== Test Documents
+
 * Maintain a collection of test documents
 * Include both valid and invalid examples
 * Document the purpose of each test file
 * Version control test data
 
 ==== Test Fixtures
+
 * Use pytest fixtures for common setup
 * Share test data between related tests
 * Clean up test environment after each test
@@ -243,6 +248,7 @@ class TestRuleName(unittest.TestCase):
 === Test Checklists
 
 ==== New Feature Checklist
+
 * [ ] Unit tests written
 * [ ] Integration tests updated
 * [ ] System tests verified
@@ -250,6 +256,7 @@ class TestRuleName(unittest.TestCase):
 * [ ] Documentation updated
 
 ==== Test Review Checklist
+
 * [ ] Tests follow patterns
 * [ ] Coverage adequate
 * [ ] Edge cases covered

--- a/docs/requirements.adoc
+++ b/docs/requirements.adoc
@@ -146,17 +146,20 @@ The rules are organized into the following categories:
 == Implementation Phases
 
 === Phase 1 - Core Rules (Completed)
+
 * ✅ Heading hierarchy and format (HEAD001, HEAD002, HEAD003)
 * ✅ Block termination and spacing (BLOCK001, BLOCK002)
 * ✅ Whitespace rules (WS001)
 * ✅ Image validation (IMG001)
 
 === Phase 2 - Enhancement Rules (Current)
+
 * 🔲 Table validation (TABLE001, TABLE002, TABLE003)
 * 🔲 Format rules (FMT001, FMT002, FMT003)
 * 🔲 Link validation (LINK001, LINK002)
 
 === Phase 3 - Polish Rules (Planned)
+
 * 🔲 IDE integration
 * 🔲 Git pre-commit hooks
 * 🔲 Custom rule development
@@ -181,16 +184,19 @@ The linter supports the following output formats:
 == Future Considerations
 
 === Technical Enhancements
+
 * Performance optimization for large documents
 * Parallel processing for multiple files
 * Incremental checking for changed files only
 
 === Integration Features
+
 * IDE plugins (VS Code, IntelliJ)
 * CI/CD pipeline integration
 * Pre-commit hook templates
 
 === Rule Development
+
 * Rule development guide
 * Custom rule API
 * Rule testing framework

--- a/docs/test-results/test-report.html
+++ b/docs/test-results/test-report.html
@@ -1,1091 +1,1157 @@
 <!DOCTYPE html>
 <html>
-  <head>
+<head>
     <meta charset="utf-8"/>
     <title id="head-title">test_report_20241221_224323.html</title>
-      <style type="text/css">body {
-  font-family: Helvetica, Arial, sans-serif;
-  font-size: 12px;
-  /* do not increase min-width as some may use split screens */
-  min-width: 800px;
-  color: #999;
-}
+    <style type="text/css">body {
+        font-family: Helvetica, Arial, sans-serif;
+        font-size: 12px;
+        /* do not increase min-width as some may use split screens */
+        min-width: 800px;
+        color: #999;
+    }
 
-h1 {
-  font-size: 24px;
-  color: black;
-}
+    h1 {
+        font-size: 24px;
+        color: black;
+    }
 
-h2 {
-  font-size: 16px;
-  color: black;
-}
+    h2 {
+        font-size: 16px;
+        color: black;
+    }
 
-p {
-  color: black;
-}
+    p {
+        color: black;
+    }
 
-a {
-  color: #999;
-}
+    a {
+        color: #999;
+    }
 
-table {
-  border-collapse: collapse;
-}
+    table {
+        border-collapse: collapse;
+    }
 
-/******************************
- * SUMMARY INFORMATION
- ******************************/
-#environment td {
-  padding: 5px;
-  border: 1px solid #e6e6e6;
-  vertical-align: top;
-}
-#environment tr:nth-child(odd) {
-  background-color: #f6f6f6;
-}
-#environment ul {
-  margin: 0;
-  padding: 0 20px;
-}
+    /******************************
+     * SUMMARY INFORMATION
+     ******************************/
+    #environment td {
+        padding: 5px;
+        border: 1px solid #e6e6e6;
+        vertical-align: top;
+    }
 
-/******************************
- * TEST RESULT COLORS
- ******************************/
-span.passed,
-.passed .col-result {
-  color: green;
-}
+    #environment tr:nth-child(odd) {
+        background-color: #f6f6f6;
+    }
 
-span.skipped,
-span.xfailed,
-span.rerun,
-.skipped .col-result,
-.xfailed .col-result,
-.rerun .col-result {
-  color: orange;
-}
+    #environment ul {
+        margin: 0;
+        padding: 0 20px;
+    }
 
-span.error,
-span.failed,
-span.xpassed,
-.error .col-result,
-.failed .col-result,
-.xpassed .col-result {
-  color: red;
-}
+    /******************************
+     * TEST RESULT COLORS
+     ******************************/
+    span.passed,
+    .passed .col-result {
+        color: green;
+    }
 
-.col-links__extra {
-  margin-right: 3px;
-}
+    span.skipped,
+    span.xfailed,
+    span.rerun,
+    .skipped .col-result,
+    .xfailed .col-result,
+    .rerun .col-result {
+        color: orange;
+    }
 
-/******************************
- * RESULTS TABLE
- *
- * 1. Table Layout
- * 2. Extra
- * 3. Sorting items
- *
- ******************************/
-/*------------------
- * 1. Table Layout
- *------------------*/
-#results-table {
-  border: 1px solid #e6e6e6;
-  color: #999;
-  font-size: 12px;
-  width: 100%;
-}
-#results-table th,
-#results-table td {
-  padding: 5px;
-  border: 1px solid #e6e6e6;
-  text-align: left;
-}
-#results-table th {
-  font-weight: bold;
-}
+    span.error,
+    span.failed,
+    span.xpassed,
+    .error .col-result,
+    .failed .col-result,
+    .xpassed .col-result {
+        color: red;
+    }
 
-/*------------------
- * 2. Extra
- *------------------*/
-.logwrapper {
-  max-height: 230px;
-  overflow-y: scroll;
-  background-color: #e6e6e6;
-}
-.logwrapper.expanded {
-  max-height: none;
-}
-.logwrapper.expanded .logexpander:after {
-  content: "collapse [-]";
-}
-.logwrapper .logexpander {
-  z-index: 1;
-  position: sticky;
-  top: 10px;
-  width: max-content;
-  border: 1px solid;
-  border-radius: 3px;
-  padding: 5px 7px;
-  margin: 10px 0 10px calc(100% - 80px);
-  cursor: pointer;
-  background-color: #e6e6e6;
-}
-.logwrapper .logexpander:after {
-  content: "expand [+]";
-}
-.logwrapper .logexpander:hover {
-  color: #000;
-  border-color: #000;
-}
-.logwrapper .log {
-  min-height: 40px;
-  position: relative;
-  top: -50px;
-  height: calc(100% + 50px);
-  border: 1px solid #e6e6e6;
-  color: black;
-  display: block;
-  font-family: "Courier New", Courier, monospace;
-  padding: 5px;
-  padding-right: 80px;
-  white-space: pre-wrap;
-}
+    .col-links__extra {
+        margin-right: 3px;
+    }
 
-div.media {
-  border: 1px solid #e6e6e6;
-  float: right;
-  height: 240px;
-  margin: 0 5px;
-  overflow: hidden;
-  width: 320px;
-}
+    /******************************
+     * RESULTS TABLE
+     *
+     * 1. Table Layout
+     * 2. Extra
+     * 3. Sorting items
+     *
+     ******************************/
+    /*------------------
+     * 1. Table Layout
+     *------------------*/
+    #results-table {
+        border: 1px solid #e6e6e6;
+        color: #999;
+        font-size: 12px;
+        width: 100%;
+    }
 
-.media-container {
-  display: grid;
-  grid-template-columns: 25px auto 25px;
-  align-items: center;
-  flex: 1 1;
-  overflow: hidden;
-  height: 200px;
-}
+    #results-table th,
+    #results-table td {
+        padding: 5px;
+        border: 1px solid #e6e6e6;
+        text-align: left;
+    }
 
-.media-container--fullscreen {
-  grid-template-columns: 0px auto 0px;
-}
+    #results-table th {
+        font-weight: bold;
+    }
 
-.media-container__nav--right,
-.media-container__nav--left {
-  text-align: center;
-  cursor: pointer;
-}
+    /*------------------
+     * 2. Extra
+     *------------------*/
+    .logwrapper {
+        max-height: 230px;
+        overflow-y: scroll;
+        background-color: #e6e6e6;
+    }
 
-.media-container__viewport {
-  cursor: pointer;
-  text-align: center;
-  height: inherit;
-}
-.media-container__viewport img,
-.media-container__viewport video {
-  object-fit: cover;
-  width: 100%;
-  max-height: 100%;
-}
+    .logwrapper.expanded {
+        max-height: none;
+    }
 
-.media__name,
-.media__counter {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-around;
-  flex: 0 0 25px;
-  align-items: center;
-}
+    .logwrapper.expanded .logexpander:after {
+        content: "collapse [-]";
+    }
 
-.collapsible td:not(.col-links) {
-  cursor: pointer;
-}
-.collapsible td:not(.col-links):hover::after {
-  color: #bbb;
-  font-style: italic;
-  cursor: pointer;
-}
+    .logwrapper .logexpander {
+        z-index: 1;
+        position: sticky;
+        top: 10px;
+        width: max-content;
+        border: 1px solid;
+        border-radius: 3px;
+        padding: 5px 7px;
+        margin: 10px 0 10px calc(100% - 80px);
+        cursor: pointer;
+        background-color: #e6e6e6;
+    }
 
-.col-result {
-  width: 130px;
-}
-.col-result:hover::after {
-  content: " (hide details)";
-}
+    .logwrapper .logexpander:after {
+        content: "expand [+]";
+    }
 
-.col-result.collapsed:hover::after {
-  content: " (show details)";
-}
+    .logwrapper .logexpander:hover {
+        color: #000;
+        border-color: #000;
+    }
 
-#environment-header h2:hover::after {
-  content: " (hide details)";
-  color: #bbb;
-  font-style: italic;
-  cursor: pointer;
-  font-size: 12px;
-}
+    .logwrapper .log {
+        min-height: 40px;
+        position: relative;
+        top: -50px;
+        height: calc(100% + 50px);
+        border: 1px solid #e6e6e6;
+        color: black;
+        display: block;
+        font-family: "Courier New", Courier, monospace;
+        padding: 5px;
+        padding-right: 80px;
+        white-space: pre-wrap;
+    }
 
-#environment-header.collapsed h2:hover::after {
-  content: " (show details)";
-  color: #bbb;
-  font-style: italic;
-  cursor: pointer;
-  font-size: 12px;
-}
+    div.media {
+        border: 1px solid #e6e6e6;
+        float: right;
+        height: 240px;
+        margin: 0 5px;
+        overflow: hidden;
+        width: 320px;
+    }
 
-/*------------------
- * 3. Sorting items
- *------------------*/
-.sortable {
-  cursor: pointer;
-}
-.sortable.desc:after {
-  content: " ";
-  position: relative;
-  left: 5px;
-  bottom: -12.5px;
-  border: 10px solid #4caf50;
-  border-bottom: 0;
-  border-left-color: transparent;
-  border-right-color: transparent;
-}
-.sortable.asc:after {
-  content: " ";
-  position: relative;
-  left: 5px;
-  bottom: 12.5px;
-  border: 10px solid #4caf50;
-  border-top: 0;
-  border-left-color: transparent;
-  border-right-color: transparent;
-}
+    .media-container {
+        display: grid;
+        grid-template-columns: 25px auto 25px;
+        align-items: center;
+        flex: 1 1;
+        overflow: hidden;
+        height: 200px;
+    }
 
-.hidden, .summary__reload__button.hidden {
-  display: none;
-}
+    .media-container--fullscreen {
+        grid-template-columns: 0px auto 0px;
+    }
 
-.summary__data {
-  flex: 0 0 550px;
-}
-.summary__reload {
-  flex: 1 1;
-  display: flex;
-  justify-content: center;
-}
-.summary__reload__button {
-  flex: 0 0 300px;
-  display: flex;
-  color: white;
-  font-weight: bold;
-  background-color: #4caf50;
-  text-align: center;
-  justify-content: center;
-  align-items: center;
-  border-radius: 3px;
-  cursor: pointer;
-}
-.summary__reload__button:hover {
-  background-color: #46a049;
-}
-.summary__spacer {
-  flex: 0 0 550px;
-}
+    .media-container__nav--right,
+    .media-container__nav--left {
+        text-align: center;
+        cursor: pointer;
+    }
 
-.controls {
-  display: flex;
-  justify-content: space-between;
-}
+    .media-container__viewport {
+        cursor: pointer;
+        text-align: center;
+        height: inherit;
+    }
 
-.filters,
-.collapse {
-  display: flex;
-  align-items: center;
-}
-.filters button,
-.collapse button {
-  color: #999;
-  border: none;
-  background: none;
-  cursor: pointer;
-  text-decoration: underline;
-}
-.filters button:hover,
-.collapse button:hover {
-  color: #ccc;
-}
+    .media-container__viewport img,
+    .media-container__viewport video {
+        object-fit: cover;
+        width: 100%;
+        max-height: 100%;
+    }
 
-.filter__label {
-  margin-right: 10px;
-}
+    .media__name,
+    .media__counter {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-around;
+        flex: 0 0 25px;
+        align-items: center;
+    }
 
-      </style>
-    
-  </head>
-  <body>
-    <h1 id="title">test_report_20241221_224323.html</h1>
-    <p>Report generated on 21-Dec-2024 at 22:43:25 by <a href="https://pypi.python.org/pypi/pytest-html">pytest-html</a>
-        v4.1.1</p>
-    <div id="environment-header">
-      <h2>Environment</h2>
-    </div>
-    <table id="environment"></table>
-    <!-- TEMPLATES -->
-      <template id="template_environment_row">
-      <tr>
+    .collapsible td:not(.col-links) {
+        cursor: pointer;
+    }
+
+    .collapsible td:not(.col-links):hover::after {
+        color: #bbb;
+        font-style: italic;
+        cursor: pointer;
+    }
+
+    .col-result {
+        width: 130px;
+    }
+
+    .col-result:hover::after {
+        content: " (hide details)";
+    }
+
+    .col-result.collapsed:hover::after {
+        content: " (show details)";
+    }
+
+    #environment-header h2:hover::after {
+        content: " (hide details)";
+        color: #bbb;
+        font-style: italic;
+        cursor: pointer;
+        font-size: 12px;
+    }
+
+    #environment-header.collapsed h2:hover::after {
+        content: " (show details)";
+        color: #bbb;
+        font-style: italic;
+        cursor: pointer;
+        font-size: 12px;
+    }
+
+    /*------------------
+     * 3. Sorting items
+     *------------------*/
+    .sortable {
+        cursor: pointer;
+    }
+
+    .sortable.desc:after {
+        content: " ";
+        position: relative;
+        left: 5px;
+        bottom: -12.5px;
+        border: 10px solid #4caf50;
+        border-bottom: 0;
+        border-left-color: transparent;
+        border-right-color: transparent;
+    }
+
+    .sortable.asc:after {
+        content: " ";
+        position: relative;
+        left: 5px;
+        bottom: 12.5px;
+        border: 10px solid #4caf50;
+        border-top: 0;
+        border-left-color: transparent;
+        border-right-color: transparent;
+    }
+
+    .hidden, .summary__reload__button.hidden {
+        display: none;
+    }
+
+    .summary__data {
+        flex: 0 0 550px;
+    }
+
+    .summary__reload {
+        flex: 1 1;
+        display: flex;
+        justify-content: center;
+    }
+
+    .summary__reload__button {
+        flex: 0 0 300px;
+        display: flex;
+        color: white;
+        font-weight: bold;
+        background-color: #4caf50;
+        text-align: center;
+        justify-content: center;
+        align-items: center;
+        border-radius: 3px;
+        cursor: pointer;
+    }
+
+    .summary__reload__button:hover {
+        background-color: #46a049;
+    }
+
+    .summary__spacer {
+        flex: 0 0 550px;
+    }
+
+    .controls {
+        display: flex;
+        justify-content: space-between;
+    }
+
+    .filters,
+    .collapse {
+        display: flex;
+        align-items: center;
+    }
+
+    .filters button,
+    .collapse button {
+        color: #999;
+        border: none;
+        background: none;
+        cursor: pointer;
+        text-decoration: underline;
+    }
+
+    .filters button:hover,
+    .collapse button:hover {
+        color: #ccc;
+    }
+
+    .filter__label {
+        margin-right: 10px;
+    }
+
+    </style>
+
+</head>
+<body>
+<h1 id="title">test_report_20241221_224323.html</h1>
+<p>Report generated on 21-Dec-2024 at 22:43:25 by <a href="https://pypi.python.org/pypi/pytest-html">pytest-html</a>
+    v4.1.1</p>
+<div id="environment-header">
+    <h2>Environment</h2>
+</div>
+<table id="environment"></table>
+<!-- TEMPLATES -->
+<template id="template_environment_row">
+    <tr>
         <td></td>
         <td></td>
-      </tr>
-    </template>
-    <template id="template_results-table__body--empty">
-      <tbody class="results-table-row">
-        <tr id="not-found-message">
-          <td colspan="4">No results found. Check the filters.</th>
-        </tr>
-    </template>
-    <template id="template_results-table__tbody">
-      <tbody class="results-table-row">
-        <tr class="collapsible">
-        </tr>
-        <tr class="extras-row">
-          <td class="extra" colspan="4">
+    </tr>
+</template>
+<template id="template_results-table__body--empty">
+    <tbody class="results-table-row">
+    <tr id="not-found-message">
+        <td colspan="4">No results found. Check the filters.</th>
+    </tr>
+</template>
+<template id="template_results-table__tbody">
+    <tbody class="results-table-row">
+    <tr class="collapsible">
+    </tr>
+    <tr class="extras-row">
+        <td class="extra" colspan="4">
             <div class="extraHTML"></div>
             <div class="media">
-              <div class="media-container">
-                  <div class="media-container__nav--left"><</div>
-                  <div class="media-container__viewport">
-                    <img src="" />
-                    <video controls>
-                      <source src="" type="video/mp4">
-                    </video>
-                  </div>
-                  <div class="media-container__nav--right">></div>
+                <div class="media-container">
+                    <div class="media-container__nav--left"><</div>
+                    <div class="media-container__viewport">
+                        <img src=""/>
+                        <video controls>
+                            <source src="" type="video/mp4">
+                        </video>
+                    </div>
+                    <div class="media-container__nav--right">></div>
                 </div>
                 <div class="media__name"></div>
                 <div class="media__counter"></div>
             </div>
             <div class="logwrapper">
-              <div class="logexpander"></div>
-              <div class="log"></div>
+                <div class="logexpander"></div>
+                <div class="log"></div>
             </div>
-          </td>
-        </tr>
-      </tbody>
-    </template>
-    <!-- END TEMPLATES -->
-    <div class="summary">
-      <div class="summary__data">
+        </td>
+    </tr>
+    </tbody>
+</template>
+<!-- END TEMPLATES -->
+<div class="summary">
+    <div class="summary__data">
         <h2>Summary</h2>
         <div class="additional-summary prefix">
         </div>
         <p class="run-count">127 tests took 180 ms.</p>
         <p class="filter">(Un)check the boxes to filter the results.</p>
         <div class="summary__reload">
-          <div class="summary__reload__button hidden" onclick="location.reload()">
-            <div>There are still tests running. <br />Reload this page to get the latest results!</div>
-          </div>
+            <div class="summary__reload__button hidden" onclick="location.reload()">
+                <div>There are still tests running. <br/>Reload this page to get the latest results!</div>
+            </div>
         </div>
         <div class="summary__spacer"></div>
         <div class="controls">
-          <div class="filters">
-            <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="failed" disabled/>
-            <span class="failed">0 Failed,</span>
-            <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="passed" />
-            <span class="passed">127 Passed,</span>
-            <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="skipped" disabled/>
-            <span class="skipped">0 Skipped,</span>
-            <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="xfailed" disabled/>
-            <span class="xfailed">0 Expected failures,</span>
-            <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="xpassed" disabled/>
-            <span class="xpassed">0 Unexpected passes,</span>
-            <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="error" disabled/>
-            <span class="error">0 Errors,</span>
-            <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="rerun" disabled/>
-            <span class="rerun">0 Reruns</span>
-          </div>
-          <div class="collapse">
-            <button id="show_all_details">Show all details</button>&nbsp;/&nbsp;<button id="hide_all_details">Hide all details</button>
-          </div>
+            <div class="filters">
+                <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="failed"
+                       disabled/>
+                <span class="failed">0 Failed,</span>
+                <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="passed"/>
+                <span class="passed">127 Passed,</span>
+                <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="skipped"
+                       disabled/>
+                <span class="skipped">0 Skipped,</span>
+                <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="xfailed"
+                       disabled/>
+                <span class="xfailed">0 Expected failures,</span>
+                <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="xpassed"
+                       disabled/>
+                <span class="xpassed">0 Unexpected passes,</span>
+                <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="error"
+                       disabled/>
+                <span class="error">0 Errors,</span>
+                <input checked="true" class="filter" name="filter_checkbox" type="checkbox" data-test-result="rerun"
+                       disabled/>
+                <span class="rerun">0 Reruns</span>
+            </div>
+            <div class="collapse">
+                <button id="show_all_details">Show all details</button>&nbsp;/&nbsp;<button id="hide_all_details">Hide
+                all details
+            </button>
+            </div>
         </div>
-      </div>
-      <div class="additional-summary summary">
-      </div>
-      <div class="additional-summary postfix">
-      </div>
     </div>
-    <table id="results-table">
-      <thead id="results-table-head">
-        <tr>
-          <th class="sortable" data-column-type="result">Result</th>
-          <th class="sortable" data-column-type="testId">Test</th>
-          <th class="sortable" data-column-type="duration">Duration</th>
-          <th>Links</th>
-        </tr>
-      </thead>
-    </table>
-  </body>
-  <footer>
-    <div id="data-container" data-jsonblob="{&#34;environment&#34;: {&#34;Python&#34;: &#34;3.12.7&#34;, &#34;Platform&#34;: &#34;Linux-6.1.91-060191-generic-x86_64-with-glibc2.35&#34;, &#34;Packages&#34;: {&#34;pytest&#34;: &#34;8.3.4&#34;, &#34;pluggy&#34;: &#34;1.5.0&#34;}, &#34;Plugins&#34;: {&#34;metadata&#34;: &#34;3.1.1&#34;, &#34;cov&#34;: &#34;6.0.0&#34;, &#34;html&#34;: &#34;4.1.1&#34;, &#34;anyio&#34;: &#34;4.6.2.post1&#34;, &#34;pylama&#34;: &#34;8.4.1&#34;}, &#34;JAVA_HOME&#34;: &#34;/home/gitpod/.sdkman/candidates/java/current&#34;}, &#34;tests&#34;: {&#34;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_multiple_blocks&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_multiple_blocks&#34;, &#34;duration&#34;: &#34;4 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_multiple_blocks&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;4 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_terminated_block&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_terminated_block&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_terminated_block&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_unterminated_block&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_unterminated_block&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_unterminated_block&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_correct_spacing&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_correct_spacing&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_correct_spacing&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_heading_exception&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_heading_exception&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_heading_exception&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_missing_space_after&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_missing_space_after&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_missing_space_after&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_missing_space_before&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_missing_space_before&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_missing_space_before&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingFormatRule::test_invalid_format&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingFormatRule::test_invalid_format&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingFormatRule::test_invalid_format&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingFormatRule::test_valid_format&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingFormatRule::test_valid_format&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingFormatRule::test_valid_format&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_empty_document&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_empty_document&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_empty_document&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_heading_underline_not_counted&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_heading_underline_not_counted&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_heading_underline_not_counted&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_multiple_skipped_levels&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_multiple_skipped_levels&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_multiple_skipped_levels&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_no_headings&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_no_headings&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_no_headings&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_skipped_heading_level&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_skipped_heading_level&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_skipped_heading_level&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_valid_heading_sequence&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_valid_heading_sequence&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_valid_heading_sequence&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestMultipleTopLevelHeadingsRule::test_multiple_top_level&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestMultipleTopLevelHeadingsRule::test_multiple_top_level&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestMultipleTopLevelHeadingsRule::test_multiple_top_level&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestMultipleTopLevelHeadingsRule::test_single_top_level&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestMultipleTopLevelHeadingsRule::test_single_top_level&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestMultipleTopLevelHeadingsRule::test_single_top_level&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_attribute_parsing&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_attribute_parsing&#34;, &#34;duration&#34;: &#34;3 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_attribute_parsing&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;3 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_block_image_complete&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_block_image_complete&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_block_image_complete&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_block_image_missing_attributes&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_block_image_missing_attributes&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_block_image_missing_attributes&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_external_url&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_external_url&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_external_url&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_inline_image_with_alt&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_inline_image_with_alt&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_inline_image_with_alt&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_inline_image_without_alt&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_inline_image_without_alt&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_inline_image_without_alt&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_multiple_images_per_line&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_multiple_images_per_line&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_multiple_images_per_line&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_short_alt_text&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_short_alt_text&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_short_alt_text&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_valid_local_image&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_valid_local_image&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_valid_local_image&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableFormatRule::test_misaligned_columns&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableFormatRule::test_misaligned_columns&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableFormatRule::test_misaligned_columns&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableFormatRule::test_missing_header_separator&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableFormatRule::test_missing_header_separator&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableFormatRule::test_missing_header_separator&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableFormatRule::test_valid_table&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableFormatRule::test_valid_table&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableFormatRule::test_valid_table&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableStructureRule::test_consistent_columns&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableStructureRule::test_consistent_columns&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableStructureRule::test_consistent_columns&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableStructureRule::test_empty_table&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableStructureRule::test_empty_table&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableStructureRule::test_empty_table&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableStructureRule::test_inconsistent_columns&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableStructureRule::test_inconsistent_columns&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableStructureRule::test_inconsistent_columns&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableContentRule::test_simple_content&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableContentRule::test_simple_content&#34;, &#34;duration&#34;: &#34;3 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableContentRule::test_simple_content&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;3 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableContentRule::test_undeclared_list&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableContentRule::test_undeclared_list&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableContentRule::test_undeclared_list&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_admonition_block_spacing&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_admonition_block_spacing&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_admonition_block_spacing&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_list_marker_spacing&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_list_marker_spacing&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_list_marker_spacing&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_multiple_empty_lines&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_multiple_empty_lines&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_multiple_empty_lines&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_section_title_spacing&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_section_title_spacing&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_section_title_spacing&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_tabs&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_tabs&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_tabs&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_trailing_whitespace&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_trailing_whitespace&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_trailing_whitespace&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_valid_document&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_valid_document&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_valid_document&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestSeverity::test_severity_comparison&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestSeverity::test_severity_comparison&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestSeverity::test_severity_comparison&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestSeverity::test_severity_string&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestSeverity::test_severity_string&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestSeverity::test_severity_string&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestSeverity::test_severity_values&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestSeverity::test_severity_values&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestSeverity::test_severity_values&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestPosition::test_position_equality&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestPosition::test_position_equality&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestPosition::test_position_equality&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestPosition::test_position_with_line_and_column&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestPosition::test_position_with_line_and_column&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestPosition::test_position_with_line_and_column&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestPosition::test_position_with_line_only&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestPosition::test_position_with_line_only&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestPosition::test_position_with_line_only&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestFinding::test_finding_complete&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestFinding::test_finding_complete&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestFinding::test_finding_complete&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestFinding::test_finding_equality&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestFinding::test_finding_equality&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestFinding::test_finding_equality&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestFinding::test_finding_minimal&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestFinding::test_finding_minimal&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestFinding::test_finding_minimal&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRule::test_base_rule_methods&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRule::test_base_rule_methods&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRule::test_base_rule_methods&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRule::test_check_line&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRule::test_check_line&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRule::test_check_line&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRule::test_check_method&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRule::test_check_method&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRule::test_check_method&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRule::test_rule_attributes&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRule::test_rule_attributes&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRule::test_rule_attributes&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRuleRegistry::test_create_all_rules&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRuleRegistry::test_create_all_rules&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRuleRegistry::test_create_all_rules&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRuleRegistry::test_get_all_rules&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRuleRegistry::test_get_all_rules&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRuleRegistry::test_get_all_rules&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRuleRegistry::test_get_nonexistent_rule&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRuleRegistry::test_get_nonexistent_rule&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRuleRegistry::test_get_nonexistent_rule&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRuleRegistry::test_get_rule&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRuleRegistry::test_get_rule&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRuleRegistry::test_get_rule&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRuleRegistry::test_register_rule&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRuleRegistry::test_register_rule&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRuleRegistry::test_register_rule&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestSeverity::test_severity_comparison&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestSeverity::test_severity_comparison&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestSeverity::test_severity_comparison&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestSeverity::test_severity_values&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestSeverity::test_severity_values&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestSeverity::test_severity_values&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestPosition::test_position_equality&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestPosition::test_position_equality&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestPosition::test_position_equality&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestPosition::test_position_with_line_and_column&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestPosition::test_position_with_line_and_column&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestPosition::test_position_with_line_and_column&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestPosition::test_position_with_line_only&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestPosition::test_position_with_line_only&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestPosition::test_position_with_line_only&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestFinding::test_finding_complete&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestFinding::test_finding_complete&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestFinding::test_finding_complete&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestFinding::test_finding_equality&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestFinding::test_finding_equality&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestFinding::test_finding_equality&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestFinding::test_finding_minimal&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestFinding::test_finding_minimal&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestFinding::test_finding_minimal&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestRule::test_check_method_base&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestRule::test_check_method_base&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestRule::test_check_method_base&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestRule::test_check_method_concrete&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestRule::test_check_method_concrete&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestRule::test_check_method_concrete&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestRule::test_rule_id&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestRule::test_rule_id&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestRule::test_rule_id&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliArgumentParsing::test_config_option&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliArgumentParsing::test_config_option&#34;, &#34;duration&#34;: &#34;3 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliArgumentParsing::test_config_option&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;3 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliArgumentParsing::test_create_parser&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliArgumentParsing::test_create_parser&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliArgumentParsing::test_create_parser&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliArgumentParsing::test_format_option&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliArgumentParsing::test_format_option&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliArgumentParsing::test_format_option&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliArgumentParsing::test_invalid_format&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliArgumentParsing::test_invalid_format&#34;, &#34;duration&#34;: &#34;5 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliArgumentParsing::test_invalid_format&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;5 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;----------------------------- Captured stderr call -----------------------------\nusage: __main__.py [-h] [--config CONFIG] [--format {console,json,html}]\n                   files [files ...]\n__main__.py: error: argument --format: invalid choice: &amp;#x27;invalid&amp;#x27; (choose from &amp;#x27;console&amp;#x27;, &amp;#x27;json&amp;#x27;, &amp;#x27;html&amp;#x27;)\n&#34;}], &#34;tests/test_cli.py::TestCliArgumentParsing::test_multiple_files&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliArgumentParsing::test_multiple_files&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliArgumentParsing::test_multiple_files&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliFileProcessing::test_file_not_found&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliFileProcessing::test_file_not_found&#34;, &#34;duration&#34;: &#34;8 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliFileProcessing::test_file_not_found&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;8 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliFileProcessing::test_file_read_error&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliFileProcessing::test_file_read_error&#34;, &#34;duration&#34;: &#34;4 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliFileProcessing::test_file_read_error&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;4 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliFileProcessing::test_lint_with_errors&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliFileProcessing::test_lint_with_errors&#34;, &#34;duration&#34;: &#34;3 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliFileProcessing::test_lint_with_errors&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;3 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;----------------------------- Captured stdout call -----------------------------\n\nResults for invalid.adoc:\n[&amp;#x27;Error: Invalid heading&amp;#x27;]\n&#34;}], &#34;tests/test_cli.py::TestCliFileProcessing::test_successful_lint&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliFileProcessing::test_successful_lint&#34;, &#34;duration&#34;: &#34;3 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliFileProcessing::test_successful_lint&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;3 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliReporters::test_default_console_reporter&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliReporters::test_default_console_reporter&#34;, &#34;duration&#34;: &#34;4 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliReporters::test_default_console_reporter&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;4 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;----------------------------- Captured stdout call -----------------------------\n\nResults for test.adoc:\n\u2713 No issues found\n&#34;}], &#34;tests/test_cli.py::TestCliReporters::test_html_reporter&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliReporters::test_html_reporter&#34;, &#34;duration&#34;: &#34;5 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliReporters::test_html_reporter&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;5 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;----------------------------- Captured stdout call -----------------------------\n\nResults for test.adoc:\n\u2713 No issues found\n&#34;}], &#34;tests/test_cli.py::TestCliReporters::test_json_reporter&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliReporters::test_json_reporter&#34;, &#34;duration&#34;: &#34;5 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliReporters::test_json_reporter&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;5 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;----------------------------- Captured stdout call -----------------------------\n\nResults for test.adoc:\n\u2713 No issues found\n&#34;}], &#34;tests/test_linter.py::test_linter_initialization&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_linter_initialization&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_linter_initialization&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_linter.py::test_lint_string_no_errors&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_lint_string_no_errors&#34;, &#34;duration&#34;: &#34;3 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_lint_string_no_errors&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;3 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_linter.py::test_lint_string_with_errors&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_lint_string_with_errors&#34;, &#34;duration&#34;: &#34;3 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_lint_string_with_errors&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;3 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_linter.py::test_lint_string_multiple_rules&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_lint_string_multiple_rules&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_lint_string_multiple_rules&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_linter.py::test_lint_file_success&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_lint_file_success&#34;, &#34;duration&#34;: &#34;6 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_lint_file_success&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;6 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_linter.py::test_lint_file_not_found&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_lint_file_not_found&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_lint_file_not_found&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_linter.py::test_lint_file_with_source_tracking&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_lint_file_with_source_tracking&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_lint_file_with_source_tracking&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_linter.py::test_integration_with_real_rules&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_integration_with_real_rules&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_integration_with_real_rules&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_lint_error_creation&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_lint_error_creation&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_lint_error_creation&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_lint_report_creation&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_lint_report_creation&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_lint_report_creation&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_lint_report_bool&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_lint_report_bool&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_lint_report_bool&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_lint_report_len&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_lint_report_len&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_lint_report_len&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_base_reporter_format&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_base_reporter_format&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_base_reporter_format&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_base_reporter_multiple_errors&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_base_reporter_multiple_errors&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_base_reporter_multiple_errors&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_json_reporter_format&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_json_reporter_format&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_json_reporter_format&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_json_reporter_complex&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_json_reporter_complex&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_json_reporter_complex&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_html_reporter_format&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_html_reporter_format&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_html_reporter_format&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_html_reporter_complex&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_html_reporter_complex&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_html_reporter_complex&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_html_reporter_styling&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_html_reporter_styling&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_html_reporter_styling&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rule_registry.py::test_rule_registry&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rule_registry.py::test_rule_registry&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rule_registry.py::test_rule_registry&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules.py::TestImports::test_import_Finding&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules.py::TestImports::test_import_Finding&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules.py::TestImports::test_import_Finding&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules.py::TestImports::test_import_Position&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules.py::TestImports::test_import_Position&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules.py::TestImports::test_import_Position&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules.py::TestImports::test_import_Rule&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules.py::TestImports::test_import_Rule&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules.py::TestImports::test_import_Rule&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules.py::TestImports::test_import_RuleRegistry&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules.py::TestImports::test_import_RuleRegistry&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules.py::TestImports::test_import_RuleRegistry&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules.py::TestImports::test_import_Severity&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules.py::TestImports::test_import_Severity&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules.py::TestImports::test_import_Severity&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules_imports.py::test_severity_import&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules_imports.py::test_severity_import&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules_imports.py::test_severity_import&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules_imports.py::test_position_import&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules_imports.py::test_position_import&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules_imports.py::test_position_import&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules_imports.py::test_finding_import&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules_imports.py::test_finding_import&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules_imports.py::test_finding_import&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules_imports.py::test_rule_import&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules_imports.py::test_rule_import&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules_imports.py::test_rule_import&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules_imports.py::test_rule_registry_import&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules_imports.py::test_rule_registry_import&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules_imports.py::test_rule_registry_import&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules_imports.py::test_all_variable&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules_imports.py::test_all_variable&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules_imports.py::test_all_variable&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableFormatRule::test_check_column_alignment&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableFormatRule::test_check_column_alignment&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableFormatRule::test_check_column_alignment&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableFormatRule::test_check_complete&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableFormatRule::test_check_complete&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableFormatRule::test_check_complete&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableFormatRule::test_check_header_separator&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableFormatRule::test_check_header_separator&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableFormatRule::test_check_header_separator&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableFormatRule::test_extract_table_lines&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableFormatRule::test_extract_table_lines&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableFormatRule::test_extract_table_lines&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableStructureRule::test_check_complete&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableStructureRule::test_check_complete&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableStructureRule::test_check_complete&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableStructureRule::test_check_table_structure_consistent&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableStructureRule::test_check_table_structure_consistent&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableStructureRule::test_check_table_structure_consistent&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableStructureRule::test_check_table_structure_inconsistent&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableStructureRule::test_check_table_structure_inconsistent&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableStructureRule::test_check_table_structure_inconsistent&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableStructureRule::test_count_columns&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableStructureRule::test_count_columns&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableStructureRule::test_count_columns&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableStructureRule::test_empty_table&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableStructureRule::test_empty_table&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableStructureRule::test_empty_table&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_list_with_prefix&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_list_with_prefix&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_list_with_prefix&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_list_without_prefix&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_list_without_prefix&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_list_without_prefix&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_simple&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_simple&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_simple&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableContentRule::test_check_complete&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableContentRule::test_check_complete&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableContentRule::test_check_complete&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableContentRule::test_extract_cells&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableContentRule::test_extract_cells&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableContentRule::test_extract_cells&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}]}, &#34;renderCollapsed&#34;: [&#34;passed&#34;], &#34;initialSort&#34;: &#34;result&#34;, &#34;title&#34;: &#34;test_report_20241221_224323.html&#34;}"></div>
+    <div class="additional-summary summary">
+    </div>
+    <div class="additional-summary postfix">
+    </div>
+</div>
+<table id="results-table">
+    <thead id="results-table-head">
+    <tr>
+        <th class="sortable" data-column-type="result">Result</th>
+        <th class="sortable" data-column-type="testId">Test</th>
+        <th class="sortable" data-column-type="duration">Duration</th>
+        <th>Links</th>
+    </tr>
+    </thead>
+</table>
+</body>
+<footer>
+    <div id="data-container"
+         data-jsonblob="{&#34;environment&#34;: {&#34;Python&#34;: &#34;3.12.7&#34;, &#34;Platform&#34;: &#34;Linux-6.1.91-060191-generic-x86_64-with-glibc2.35&#34;, &#34;Packages&#34;: {&#34;pytest&#34;: &#34;8.3.4&#34;, &#34;pluggy&#34;: &#34;1.5.0&#34;}, &#34;Plugins&#34;: {&#34;metadata&#34;: &#34;3.1.1&#34;, &#34;cov&#34;: &#34;6.0.0&#34;, &#34;html&#34;: &#34;4.1.1&#34;, &#34;anyio&#34;: &#34;4.6.2.post1&#34;, &#34;pylama&#34;: &#34;8.4.1&#34;}, &#34;JAVA_HOME&#34;: &#34;/home/gitpod/.sdkman/candidates/java/current&#34;}, &#34;tests&#34;: {&#34;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_multiple_blocks&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_multiple_blocks&#34;, &#34;duration&#34;: &#34;4 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_multiple_blocks&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;4 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_terminated_block&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_terminated_block&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_terminated_block&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_unterminated_block&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_unterminated_block&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_block_rules.py::TestUnterminatedBlockRule::test_unterminated_block&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_correct_spacing&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_correct_spacing&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_correct_spacing&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_heading_exception&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_heading_exception&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_heading_exception&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_missing_space_after&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_missing_space_after&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_missing_space_after&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_missing_space_before&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_missing_space_before&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_block_rules.py::TestBlockSpacingRule::test_missing_space_before&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingFormatRule::test_invalid_format&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingFormatRule::test_invalid_format&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingFormatRule::test_invalid_format&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingFormatRule::test_valid_format&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingFormatRule::test_valid_format&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingFormatRule::test_valid_format&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_empty_document&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_empty_document&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_empty_document&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_heading_underline_not_counted&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_heading_underline_not_counted&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_heading_underline_not_counted&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_multiple_skipped_levels&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_multiple_skipped_levels&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_multiple_skipped_levels&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_no_headings&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_no_headings&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_no_headings&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_skipped_heading_level&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_skipped_heading_level&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_skipped_heading_level&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_valid_heading_sequence&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_valid_heading_sequence&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestHeadingHierarchyRule::test_valid_heading_sequence&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestMultipleTopLevelHeadingsRule::test_multiple_top_level&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestMultipleTopLevelHeadingsRule::test_multiple_top_level&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestMultipleTopLevelHeadingsRule::test_multiple_top_level&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_heading_rules.py::TestMultipleTopLevelHeadingsRule::test_single_top_level&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_heading_rules.py::TestMultipleTopLevelHeadingsRule::test_single_top_level&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_heading_rules.py::TestMultipleTopLevelHeadingsRule::test_single_top_level&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_attribute_parsing&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_attribute_parsing&#34;, &#34;duration&#34;: &#34;3 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_attribute_parsing&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;3 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_block_image_complete&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_block_image_complete&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_block_image_complete&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_block_image_missing_attributes&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_block_image_missing_attributes&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_block_image_missing_attributes&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_external_url&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_external_url&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_external_url&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_inline_image_with_alt&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_inline_image_with_alt&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_inline_image_with_alt&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_inline_image_without_alt&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_inline_image_without_alt&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_inline_image_without_alt&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_multiple_images_per_line&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_multiple_images_per_line&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_multiple_images_per_line&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_short_alt_text&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_short_alt_text&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_short_alt_text&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_valid_local_image&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_image_rules.py::TestImageAttributesRule::test_valid_local_image&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_image_rules.py::TestImageAttributesRule::test_valid_local_image&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableFormatRule::test_misaligned_columns&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableFormatRule::test_misaligned_columns&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableFormatRule::test_misaligned_columns&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableFormatRule::test_missing_header_separator&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableFormatRule::test_missing_header_separator&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableFormatRule::test_missing_header_separator&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableFormatRule::test_valid_table&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableFormatRule::test_valid_table&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableFormatRule::test_valid_table&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableStructureRule::test_consistent_columns&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableStructureRule::test_consistent_columns&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableStructureRule::test_consistent_columns&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableStructureRule::test_empty_table&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableStructureRule::test_empty_table&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableStructureRule::test_empty_table&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableStructureRule::test_inconsistent_columns&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableStructureRule::test_inconsistent_columns&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableStructureRule::test_inconsistent_columns&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableContentRule::test_simple_content&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableContentRule::test_simple_content&#34;, &#34;duration&#34;: &#34;3 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableContentRule::test_simple_content&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;3 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_table_rules.py::TestTableContentRule::test_undeclared_list&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_table_rules.py::TestTableContentRule::test_undeclared_list&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_table_rules.py::TestTableContentRule::test_undeclared_list&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_admonition_block_spacing&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_admonition_block_spacing&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_admonition_block_spacing&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_list_marker_spacing&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_list_marker_spacing&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_list_marker_spacing&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_multiple_empty_lines&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_multiple_empty_lines&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_multiple_empty_lines&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_section_title_spacing&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_section_title_spacing&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_section_title_spacing&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_tabs&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_tabs&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_tabs&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_trailing_whitespace&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_trailing_whitespace&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_trailing_whitespace&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_valid_document&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_valid_document&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/rules/test_whitespace_rules.py::TestWhitespaceRule::test_valid_document&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestSeverity::test_severity_comparison&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestSeverity::test_severity_comparison&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestSeverity::test_severity_comparison&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestSeverity::test_severity_string&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestSeverity::test_severity_string&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestSeverity::test_severity_string&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestSeverity::test_severity_values&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestSeverity::test_severity_values&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestSeverity::test_severity_values&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestPosition::test_position_equality&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestPosition::test_position_equality&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestPosition::test_position_equality&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestPosition::test_position_with_line_and_column&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestPosition::test_position_with_line_and_column&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestPosition::test_position_with_line_and_column&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestPosition::test_position_with_line_only&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestPosition::test_position_with_line_only&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestPosition::test_position_with_line_only&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestFinding::test_finding_complete&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestFinding::test_finding_complete&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestFinding::test_finding_complete&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestFinding::test_finding_equality&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestFinding::test_finding_equality&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestFinding::test_finding_equality&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestFinding::test_finding_minimal&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestFinding::test_finding_minimal&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestFinding::test_finding_minimal&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRule::test_base_rule_methods&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRule::test_base_rule_methods&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRule::test_base_rule_methods&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRule::test_check_line&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRule::test_check_line&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRule::test_check_line&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRule::test_check_method&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRule::test_check_method&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRule::test_check_method&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRule::test_rule_attributes&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRule::test_rule_attributes&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRule::test_rule_attributes&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRuleRegistry::test_create_all_rules&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRuleRegistry::test_create_all_rules&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRuleRegistry::test_create_all_rules&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRuleRegistry::test_get_all_rules&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRuleRegistry::test_get_all_rules&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRuleRegistry::test_get_all_rules&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRuleRegistry::test_get_nonexistent_rule&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRuleRegistry::test_get_nonexistent_rule&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRuleRegistry::test_get_nonexistent_rule&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRuleRegistry::test_get_rule&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRuleRegistry::test_get_rule&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRuleRegistry::test_get_rule&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base.py::TestRuleRegistry::test_register_rule&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base.py::TestRuleRegistry::test_register_rule&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base.py::TestRuleRegistry::test_register_rule&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestSeverity::test_severity_comparison&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestSeverity::test_severity_comparison&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestSeverity::test_severity_comparison&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestSeverity::test_severity_values&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestSeverity::test_severity_values&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestSeverity::test_severity_values&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestPosition::test_position_equality&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestPosition::test_position_equality&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestPosition::test_position_equality&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestPosition::test_position_with_line_and_column&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestPosition::test_position_with_line_and_column&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestPosition::test_position_with_line_and_column&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestPosition::test_position_with_line_only&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestPosition::test_position_with_line_only&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestPosition::test_position_with_line_only&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestFinding::test_finding_complete&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestFinding::test_finding_complete&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestFinding::test_finding_complete&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestFinding::test_finding_equality&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestFinding::test_finding_equality&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestFinding::test_finding_equality&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestFinding::test_finding_minimal&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestFinding::test_finding_minimal&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestFinding::test_finding_minimal&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestRule::test_check_method_base&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestRule::test_check_method_base&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestRule::test_check_method_base&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestRule::test_check_method_concrete&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestRule::test_check_method_concrete&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestRule::test_check_method_concrete&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_base_rules.py::TestRule::test_rule_id&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_base_rules.py::TestRule::test_rule_id&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_base_rules.py::TestRule::test_rule_id&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliArgumentParsing::test_config_option&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliArgumentParsing::test_config_option&#34;, &#34;duration&#34;: &#34;3 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliArgumentParsing::test_config_option&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;3 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliArgumentParsing::test_create_parser&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliArgumentParsing::test_create_parser&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliArgumentParsing::test_create_parser&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliArgumentParsing::test_format_option&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliArgumentParsing::test_format_option&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliArgumentParsing::test_format_option&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliArgumentParsing::test_invalid_format&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliArgumentParsing::test_invalid_format&#34;, &#34;duration&#34;: &#34;5 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliArgumentParsing::test_invalid_format&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;5 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;----------------------------- Captured stderr call -----------------------------\nusage: __main__.py [-h] [--config CONFIG] [--format {console,json,html}]\n                   files [files ...]\n__main__.py: error: argument --format: invalid choice: &amp;#x27;invalid&amp;#x27; (choose from &amp;#x27;console&amp;#x27;, &amp;#x27;json&amp;#x27;, &amp;#x27;html&amp;#x27;)\n&#34;}], &#34;tests/test_cli.py::TestCliArgumentParsing::test_multiple_files&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliArgumentParsing::test_multiple_files&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliArgumentParsing::test_multiple_files&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliFileProcessing::test_file_not_found&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliFileProcessing::test_file_not_found&#34;, &#34;duration&#34;: &#34;8 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliFileProcessing::test_file_not_found&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;8 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliFileProcessing::test_file_read_error&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliFileProcessing::test_file_read_error&#34;, &#34;duration&#34;: &#34;4 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliFileProcessing::test_file_read_error&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;4 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliFileProcessing::test_lint_with_errors&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliFileProcessing::test_lint_with_errors&#34;, &#34;duration&#34;: &#34;3 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliFileProcessing::test_lint_with_errors&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;3 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;----------------------------- Captured stdout call -----------------------------\n\nResults for invalid.adoc:\n[&amp;#x27;Error: Invalid heading&amp;#x27;]\n&#34;}], &#34;tests/test_cli.py::TestCliFileProcessing::test_successful_lint&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliFileProcessing::test_successful_lint&#34;, &#34;duration&#34;: &#34;3 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliFileProcessing::test_successful_lint&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;3 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_cli.py::TestCliReporters::test_default_console_reporter&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliReporters::test_default_console_reporter&#34;, &#34;duration&#34;: &#34;4 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliReporters::test_default_console_reporter&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;4 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;----------------------------- Captured stdout call -----------------------------\n\nResults for test.adoc:\n\u2713 No issues found\n&#34;}], &#34;tests/test_cli.py::TestCliReporters::test_html_reporter&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliReporters::test_html_reporter&#34;, &#34;duration&#34;: &#34;5 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliReporters::test_html_reporter&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;5 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;----------------------------- Captured stdout call -----------------------------\n\nResults for test.adoc:\n\u2713 No issues found\n&#34;}], &#34;tests/test_cli.py::TestCliReporters::test_json_reporter&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_cli.py::TestCliReporters::test_json_reporter&#34;, &#34;duration&#34;: &#34;5 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_cli.py::TestCliReporters::test_json_reporter&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;5 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;----------------------------- Captured stdout call -----------------------------\n\nResults for test.adoc:\n\u2713 No issues found\n&#34;}], &#34;tests/test_linter.py::test_linter_initialization&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_linter_initialization&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_linter_initialization&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_linter.py::test_lint_string_no_errors&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_lint_string_no_errors&#34;, &#34;duration&#34;: &#34;3 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_lint_string_no_errors&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;3 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_linter.py::test_lint_string_with_errors&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_lint_string_with_errors&#34;, &#34;duration&#34;: &#34;3 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_lint_string_with_errors&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;3 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_linter.py::test_lint_string_multiple_rules&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_lint_string_multiple_rules&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_lint_string_multiple_rules&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_linter.py::test_lint_file_success&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_lint_file_success&#34;, &#34;duration&#34;: &#34;6 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_lint_file_success&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;6 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_linter.py::test_lint_file_not_found&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_lint_file_not_found&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_lint_file_not_found&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_linter.py::test_lint_file_with_source_tracking&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_lint_file_with_source_tracking&#34;, &#34;duration&#34;: &#34;2 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_lint_file_with_source_tracking&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;2 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_linter.py::test_integration_with_real_rules&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_linter.py::test_integration_with_real_rules&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_linter.py::test_integration_with_real_rules&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_lint_error_creation&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_lint_error_creation&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_lint_error_creation&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_lint_report_creation&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_lint_report_creation&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_lint_report_creation&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_lint_report_bool&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_lint_report_bool&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_lint_report_bool&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_lint_report_len&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_lint_report_len&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_lint_report_len&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_base_reporter_format&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_base_reporter_format&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_base_reporter_format&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_base_reporter_multiple_errors&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_base_reporter_multiple_errors&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_base_reporter_multiple_errors&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_json_reporter_format&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_json_reporter_format&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_json_reporter_format&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_json_reporter_complex&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_json_reporter_complex&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_json_reporter_complex&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_html_reporter_format&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_html_reporter_format&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_html_reporter_format&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_html_reporter_complex&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_html_reporter_complex&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_html_reporter_complex&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_reporter.py::test_html_reporter_styling&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_reporter.py::test_html_reporter_styling&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_reporter.py::test_html_reporter_styling&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rule_registry.py::test_rule_registry&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rule_registry.py::test_rule_registry&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rule_registry.py::test_rule_registry&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules.py::TestImports::test_import_Finding&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules.py::TestImports::test_import_Finding&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules.py::TestImports::test_import_Finding&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules.py::TestImports::test_import_Position&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules.py::TestImports::test_import_Position&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules.py::TestImports::test_import_Position&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules.py::TestImports::test_import_Rule&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules.py::TestImports::test_import_Rule&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules.py::TestImports::test_import_Rule&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules.py::TestImports::test_import_RuleRegistry&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules.py::TestImports::test_import_RuleRegistry&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules.py::TestImports::test_import_RuleRegistry&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules.py::TestImports::test_import_Severity&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules.py::TestImports::test_import_Severity&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules.py::TestImports::test_import_Severity&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules_imports.py::test_severity_import&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules_imports.py::test_severity_import&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules_imports.py::test_severity_import&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules_imports.py::test_position_import&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules_imports.py::test_position_import&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules_imports.py::test_position_import&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules_imports.py::test_finding_import&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules_imports.py::test_finding_import&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules_imports.py::test_finding_import&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules_imports.py::test_rule_import&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules_imports.py::test_rule_import&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules_imports.py::test_rule_import&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules_imports.py::test_rule_registry_import&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules_imports.py::test_rule_registry_import&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules_imports.py::test_rule_registry_import&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_rules_imports.py::test_all_variable&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_rules_imports.py::test_all_variable&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_rules_imports.py::test_all_variable&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableFormatRule::test_check_column_alignment&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableFormatRule::test_check_column_alignment&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableFormatRule::test_check_column_alignment&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableFormatRule::test_check_complete&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableFormatRule::test_check_complete&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableFormatRule::test_check_complete&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableFormatRule::test_check_header_separator&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableFormatRule::test_check_header_separator&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableFormatRule::test_check_header_separator&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableFormatRule::test_extract_table_lines&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableFormatRule::test_extract_table_lines&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableFormatRule::test_extract_table_lines&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableStructureRule::test_check_complete&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableStructureRule::test_check_complete&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableStructureRule::test_check_complete&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableStructureRule::test_check_table_structure_consistent&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableStructureRule::test_check_table_structure_consistent&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableStructureRule::test_check_table_structure_consistent&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableStructureRule::test_check_table_structure_inconsistent&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableStructureRule::test_check_table_structure_inconsistent&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableStructureRule::test_check_table_structure_inconsistent&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableStructureRule::test_count_columns&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableStructureRule::test_count_columns&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableStructureRule::test_count_columns&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableStructureRule::test_empty_table&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableStructureRule::test_empty_table&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableStructureRule::test_empty_table&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_list_with_prefix&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_list_with_prefix&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_list_with_prefix&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_list_without_prefix&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_list_without_prefix&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_list_without_prefix&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_simple&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_simple&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableContentRule::test_check_cell_content_simple&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableContentRule::test_check_complete&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableContentRule::test_check_complete&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableContentRule::test_check_complete&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}], &#34;tests/test_table_rules.py::TestTableContentRule::test_extract_cells&#34;: [{&#34;extras&#34;: [], &#34;result&#34;: &#34;Passed&#34;, &#34;testId&#34;: &#34;tests/test_table_rules.py::TestTableContentRule::test_extract_cells&#34;, &#34;duration&#34;: &#34;1 ms&#34;, &#34;resultsTableRow&#34;: [&#34;&lt;td class=\&#34;col-result\&#34;&gt;Passed&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-testId\&#34;&gt;tests/test_table_rules.py::TestTableContentRule::test_extract_cells&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-duration\&#34;&gt;1 ms&lt;/td&gt;&#34;, &#34;&lt;td class=\&#34;col-links\&#34;&gt;&lt;/td&gt;&#34;], &#34;log&#34;: &#34;No log output captured.&#34;}]}, &#34;renderCollapsed&#34;: [&#34;passed&#34;], &#34;initialSort&#34;: &#34;result&#34;, &#34;title&#34;: &#34;test_report_20241221_224323.html&#34;}"></div>
     <script>
-      (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
-const { getCollapsedCategory, setCollapsedIds } = require('./storage.js')
+        (function () {
+            function r(e, n, t) {
+                function o(i, f) {
+                    if (!n[i]) {
+                        if (!e[i]) {
+                            var c = "function" == typeof require && require;
+                            if (!f && c) return c(i, !0);
+                            if (u) return u(i, !0);
+                            var a = new Error("Cannot find module '" + i + "'");
+                            throw a.code = "MODULE_NOT_FOUND", a
+                        }
+                        var p = n[i] = {exports: {}};
+                        e[i][0].call(p.exports, function (r) {
+                            var n = e[i][1][r];
+                            return o(n || r)
+                        }, p, p.exports, r, e, n, t)
+                    }
+                    return n[i].exports
+                }
 
-class DataManager {
-    setManager(data) {
-        const collapsedCategories = [...getCollapsedCategory(data.renderCollapsed)]
-        const collapsedIds = []
-        const tests = Object.values(data.tests).flat().map((test, index) => {
-            const collapsed = collapsedCategories.includes(test.result.toLowerCase())
-            const id = `test_${index}`
-            if (collapsed) {
-                collapsedIds.push(id)
-            }
-            return {
-                ...test,
-                id,
-                collapsed,
-            }
-        })
-        const dataBlob = { ...data, tests }
-        this.data = { ...dataBlob }
-        this.renderData = { ...dataBlob }
-        setCollapsedIds(collapsedIds)
-    }
-
-    get allData() {
-        return { ...this.data }
-    }
-
-    resetRender() {
-        this.renderData = { ...this.data }
-    }
-
-    setRender(data) {
-        this.renderData.tests = [...data]
-    }
-
-    toggleCollapsedItem(id) {
-        this.renderData.tests = this.renderData.tests.map((test) =>
-            test.id === id ? { ...test, collapsed: !test.collapsed } : test,
-        )
-    }
-
-    set allCollapsed(collapsed) {
-        this.renderData = { ...this.renderData, tests: [...this.renderData.tests.map((test) => (
-            { ...test, collapsed }
-        ))] }
-    }
-
-    get testSubset() {
-        return [...this.renderData.tests]
-    }
-
-    get environment() {
-        return this.renderData.environment
-    }
-
-    get initialSort() {
-        return this.data.initialSort
-    }
-}
-
-module.exports = {
-    manager: new DataManager(),
-}
-
-},{"./storage.js":8}],2:[function(require,module,exports){
-const mediaViewer = require('./mediaviewer.js')
-const templateEnvRow = document.getElementById('template_environment_row')
-const templateResult = document.getElementById('template_results-table__tbody')
-
-function htmlToElements(html) {
-    const temp = document.createElement('template')
-    temp.innerHTML = html
-    return temp.content.childNodes
-}
-
-const find = (selector, elem) => {
-    if (!elem) {
-        elem = document
-    }
-    return elem.querySelector(selector)
-}
-
-const findAll = (selector, elem) => {
-    if (!elem) {
-        elem = document
-    }
-    return [...elem.querySelectorAll(selector)]
-}
-
-const dom = {
-    getStaticRow: (key, value) => {
-        const envRow = templateEnvRow.content.cloneNode(true)
-        const isObj = typeof value === 'object' && value !== null
-        const values = isObj ? Object.keys(value).map((k) => `${k}: ${value[k]}`) : null
-
-        const valuesElement = htmlToElements(
-            values ? `<ul>${values.map((val) => `<li>${val}</li>`).join('')}<ul>` : `<div>${value}</div>`)[0]
-        const td = findAll('td', envRow)
-        td[0].textContent = key
-        td[1].appendChild(valuesElement)
-
-        return envRow
-    },
-    getResultTBody: ({ testId, id, log, extras, resultsTableRow, tableHtml, result, collapsed }) => {
-        const resultBody = templateResult.content.cloneNode(true)
-        resultBody.querySelector('tbody').classList.add(result.toLowerCase())
-        resultBody.querySelector('tbody').id = testId
-        resultBody.querySelector('.collapsible').dataset.id = id
-
-        resultsTableRow.forEach((html) => {
-            const t = document.createElement('template')
-            t.innerHTML = html
-            resultBody.querySelector('.collapsible').appendChild(t.content)
-        })
-
-        if (log) {
-            // Wrap lines starting with "E" with span.error to color those lines red
-            const wrappedLog = log.replace(/^E.*$/gm, (match) => `<span class="error">${match}</span>`)
-            resultBody.querySelector('.log').innerHTML = wrappedLog
-        } else {
-            resultBody.querySelector('.log').remove()
-        }
-
-        if (collapsed) {
-            resultBody.querySelector('.collapsible > td')?.classList.add('collapsed')
-            resultBody.querySelector('.extras-row').classList.add('hidden')
-        } else {
-            resultBody.querySelector('.collapsible > td')?.classList.remove('collapsed')
-        }
-
-        const media = []
-        extras?.forEach(({ name, format_type, content }) => {
-            if (['image', 'video'].includes(format_type)) {
-                media.push({ path: content, name, format_type })
+                for (var u = "function" == typeof require && require, i = 0; i < t.length; i++) o(t[i]);
+                return o
             }
 
-            if (format_type === 'html') {
-                resultBody.querySelector('.extraHTML').insertAdjacentHTML('beforeend', `<div>${content}</div>`)
-            }
-        })
-        mediaViewer.setup(resultBody, media)
-
-        // Add custom html from the pytest_html_results_table_html hook
-        tableHtml?.forEach((item) => {
-            resultBody.querySelector('td[class="extra"]').insertAdjacentHTML('beforeend', item)
-        })
-
-        return resultBody
-    },
-}
-
-module.exports = {
-    dom,
-    htmlToElements,
-    find,
-    findAll,
-}
-
-},{"./mediaviewer.js":6}],3:[function(require,module,exports){
-const { manager } = require('./datamanager.js')
-const { doSort } = require('./sort.js')
-const storageModule = require('./storage.js')
-
-const getFilteredSubSet = (filter) =>
-    manager.allData.tests.filter(({ result }) => filter.includes(result.toLowerCase()))
-
-const doInitFilter = () => {
-    const currentFilter = storageModule.getVisible()
-    const filteredSubset = getFilteredSubSet(currentFilter)
-    manager.setRender(filteredSubset)
-}
-
-const doFilter = (type, show) => {
-    if (show) {
-        storageModule.showCategory(type)
-    } else {
-        storageModule.hideCategory(type)
-    }
-
-    const currentFilter = storageModule.getVisible()
-    const filteredSubset = getFilteredSubSet(currentFilter)
-    manager.setRender(filteredSubset)
-
-    const sortColumn = storageModule.getSort()
-    doSort(sortColumn, true)
-}
-
-module.exports = {
-    doFilter,
-    doInitFilter,
-}
-
-},{"./datamanager.js":1,"./sort.js":7,"./storage.js":8}],4:[function(require,module,exports){
-const { redraw, bindEvents, renderStatic } = require('./main.js')
-const { doInitFilter } = require('./filter.js')
-const { doInitSort } = require('./sort.js')
-const { manager } = require('./datamanager.js')
-const data = JSON.parse(document.getElementById('data-container').dataset.jsonblob)
-
-function init() {
-    manager.setManager(data)
-    doInitFilter()
-    doInitSort()
-    renderStatic()
-    redraw()
-    bindEvents()
-}
-
-init()
-
-},{"./datamanager.js":1,"./filter.js":3,"./main.js":5,"./sort.js":7}],5:[function(require,module,exports){
-const { dom, find, findAll } = require('./dom.js')
-const { manager } = require('./datamanager.js')
-const { doSort } = require('./sort.js')
-const { doFilter } = require('./filter.js')
-const {
-    getVisible,
-    getCollapsedIds,
-    setCollapsedIds,
-    getSort,
-    getSortDirection,
-    possibleFilters,
-} = require('./storage.js')
-
-const removeChildren = (node) => {
-    while (node.firstChild) {
-        node.removeChild(node.firstChild)
-    }
-}
-
-const renderStatic = () => {
-    const renderEnvironmentTable = () => {
-        const environment = manager.environment
-        const rows = Object.keys(environment).map((key) => dom.getStaticRow(key, environment[key]))
-        const table = document.getElementById('environment')
-        removeChildren(table)
-        rows.forEach((row) => table.appendChild(row))
-    }
-    renderEnvironmentTable()
-}
-
-const addItemToggleListener = (elem) => {
-    elem.addEventListener('click', ({ target }) => {
-        const id = target.parentElement.dataset.id
-        manager.toggleCollapsedItem(id)
-
-        const collapsedIds = getCollapsedIds()
-        if (collapsedIds.includes(id)) {
-            const updated = collapsedIds.filter((item) => item !== id)
-            setCollapsedIds(updated)
-        } else {
-            collapsedIds.push(id)
-            setCollapsedIds(collapsedIds)
-        }
-        redraw()
-    })
-}
-
-const renderContent = (tests) => {
-    const sortAttr = getSort(manager.initialSort)
-    const sortAsc = JSON.parse(getSortDirection())
-    const rows = tests.map(dom.getResultTBody)
-    const table = document.getElementById('results-table')
-    const tableHeader = document.getElementById('results-table-head')
-
-    const newTable = document.createElement('table')
-    newTable.id = 'results-table'
-
-    // remove all sorting classes and set the relevant
-    findAll('.sortable', tableHeader).forEach((elem) => elem.classList.remove('asc', 'desc'))
-    tableHeader.querySelector(`.sortable[data-column-type="${sortAttr}"]`)?.classList.add(sortAsc ? 'desc' : 'asc')
-    newTable.appendChild(tableHeader)
-
-    if (!rows.length) {
-        const emptyTable = document.getElementById('template_results-table__body--empty').content.cloneNode(true)
-        newTable.appendChild(emptyTable)
-    } else {
-        rows.forEach((row) => {
-            if (!!row) {
-                findAll('.collapsible td:not(.col-links', row).forEach(addItemToggleListener)
-                find('.logexpander', row).addEventListener('click',
-                    (evt) => evt.target.parentNode.classList.toggle('expanded'),
-                )
-                newTable.appendChild(row)
-            }
-        })
-    }
-
-    table.replaceWith(newTable)
-}
-
-const renderDerived = () => {
-    const currentFilter = getVisible()
-    possibleFilters.forEach((result) => {
-        const input = document.querySelector(`input[data-test-result="${result}"]`)
-        input.checked = currentFilter.includes(result)
-    })
-}
-
-const bindEvents = () => {
-    const filterColumn = (evt) => {
-        const { target: element } = evt
-        const { testResult } = element.dataset
-
-        doFilter(testResult, element.checked)
-        const collapsedIds = getCollapsedIds()
-        const updated = manager.renderData.tests.map((test) => {
-            return {
-                ...test,
-                collapsed: collapsedIds.includes(test.id),
-            }
-        })
-        manager.setRender(updated)
-        redraw()
-    }
-
-    const header = document.getElementById('environment-header')
-    header.addEventListener('click', () => {
-        const table = document.getElementById('environment')
-        table.classList.toggle('hidden')
-        header.classList.toggle('collapsed')
-    })
-
-    findAll('input[name="filter_checkbox"]').forEach((elem) => {
-        elem.addEventListener('click', filterColumn)
-    })
-
-    findAll('.sortable').forEach((elem) => {
-        elem.addEventListener('click', (evt) => {
-            const { target: element } = evt
-            const { columnType } = element.dataset
-            doSort(columnType)
-            redraw()
-        })
-    })
-
-    document.getElementById('show_all_details').addEventListener('click', () => {
-        manager.allCollapsed = false
-        setCollapsedIds([])
-        redraw()
-    })
-    document.getElementById('hide_all_details').addEventListener('click', () => {
-        manager.allCollapsed = true
-        const allIds = manager.renderData.tests.map((test) => test.id)
-        setCollapsedIds(allIds)
-        redraw()
-    })
-}
-
-const redraw = () => {
-    const { testSubset } = manager
-
-    renderContent(testSubset)
-    renderDerived()
-}
-
-module.exports = {
-    redraw,
-    bindEvents,
-    renderStatic,
-}
-
-},{"./datamanager.js":1,"./dom.js":2,"./filter.js":3,"./sort.js":7,"./storage.js":8}],6:[function(require,module,exports){
-class MediaViewer {
-    constructor(assets) {
-        this.assets = assets
-        this.index = 0
-    }
-
-    nextActive() {
-        this.index = this.index === this.assets.length - 1 ? 0 : this.index + 1
-        return [this.activeFile, this.index]
-    }
-
-    prevActive() {
-        this.index = this.index === 0 ? this.assets.length - 1 : this.index -1
-        return [this.activeFile, this.index]
-    }
-
-    get currentIndex() {
-        return this.index
-    }
-
-    get activeFile() {
-        return this.assets[this.index]
-    }
-}
-
-
-const setup = (resultBody, assets) => {
-    if (!assets.length) {
-        resultBody.querySelector('.media').classList.add('hidden')
-        return
-    }
-
-    const mediaViewer = new MediaViewer(assets)
-    const container = resultBody.querySelector('.media-container')
-    const leftArrow = resultBody.querySelector('.media-container__nav--left')
-    const rightArrow = resultBody.querySelector('.media-container__nav--right')
-    const mediaName = resultBody.querySelector('.media__name')
-    const counter = resultBody.querySelector('.media__counter')
-    const imageEl = resultBody.querySelector('img')
-    const sourceEl = resultBody.querySelector('source')
-    const videoEl = resultBody.querySelector('video')
-
-    const setImg = (media, index) => {
-        if (media?.format_type === 'image') {
-            imageEl.src = media.path
-
-            imageEl.classList.remove('hidden')
-            videoEl.classList.add('hidden')
-        } else if (media?.format_type === 'video') {
-            sourceEl.src = media.path
-
-            videoEl.classList.remove('hidden')
-            imageEl.classList.add('hidden')
-        }
-
-        mediaName.innerText = media?.name
-        counter.innerText = `${index + 1} / ${assets.length}`
-    }
-    setImg(mediaViewer.activeFile, mediaViewer.currentIndex)
-
-    const moveLeft = () => {
-        const [media, index] = mediaViewer.prevActive()
-        setImg(media, index)
-    }
-    const doRight = () => {
-        const [media, index] = mediaViewer.nextActive()
-        setImg(media, index)
-    }
-    const openImg = () => {
-        window.open(mediaViewer.activeFile.path, '_blank')
-    }
-    if (assets.length === 1) {
-        container.classList.add('media-container--fullscreen')
-    } else {
-        leftArrow.addEventListener('click', moveLeft)
-        rightArrow.addEventListener('click', doRight)
-    }
-    imageEl.addEventListener('click', openImg)
-}
-
-module.exports = {
-    setup,
-}
-
-},{}],7:[function(require,module,exports){
-const { manager } = require('./datamanager.js')
-const storageModule = require('./storage.js')
-
-const genericSort = (list, key, ascending, customOrder) => {
-    let sorted
-    if (customOrder) {
-        sorted = list.sort((a, b) => {
-            const aValue = a.result.toLowerCase()
-            const bValue = b.result.toLowerCase()
-
-            const aIndex = customOrder.findIndex((item) => item.toLowerCase() === aValue)
-            const bIndex = customOrder.findIndex((item) => item.toLowerCase() === bValue)
-
-            // Compare the indices to determine the sort order
-            return aIndex - bIndex
-        })
-    } else {
-        sorted = list.sort((a, b) => a[key] === b[key] ? 0 : a[key] > b[key] ? 1 : -1)
-    }
-
-    if (ascending) {
-        sorted.reverse()
-    }
-    return sorted
-}
-
-const durationSort = (list, ascending) => {
-    const parseDuration = (duration) => {
-        if (duration.includes(':')) {
-            // If it's in the format "HH:mm:ss"
-            const [hours, minutes, seconds] = duration.split(':').map(Number)
-            return (hours * 3600 + minutes * 60 + seconds) * 1000
-        } else {
-            // If it's in the format "nnn ms"
-            return parseInt(duration)
-        }
-    }
-    const sorted = list.sort((a, b) => parseDuration(a['duration']) - parseDuration(b['duration']))
-    if (ascending) {
-        sorted.reverse()
-    }
-    return sorted
-}
-
-const doInitSort = () => {
-    const type = storageModule.getSort(manager.initialSort)
-    const ascending = storageModule.getSortDirection()
-    const list = manager.testSubset
-    const initialOrder = ['Error', 'Failed', 'Rerun', 'XFailed', 'XPassed', 'Skipped', 'Passed']
-
-    storageModule.setSort(type)
-    storageModule.setSortDirection(ascending)
-
-    if (type?.toLowerCase() === 'original') {
-        manager.setRender(list)
-    } else {
-        let sortedList
-        switch (type) {
-        case 'duration':
-            sortedList = durationSort(list, ascending)
-            break
-        case 'result':
-            sortedList = genericSort(list, type, ascending, initialOrder)
-            break
-        default:
-            sortedList = genericSort(list, type, ascending)
-            break
-        }
-        manager.setRender(sortedList)
-    }
-}
-
-const doSort = (type, skipDirection) => {
-    const newSortType = storageModule.getSort(manager.initialSort) !== type
-    const currentAsc = storageModule.getSortDirection()
-    let ascending
-    if (skipDirection) {
-        ascending = currentAsc
-    } else {
-        ascending = newSortType ? false : !currentAsc
-    }
-    storageModule.setSort(type)
-    storageModule.setSortDirection(ascending)
-
-    const list = manager.testSubset
-    const sortedList = type === 'duration' ? durationSort(list, ascending) : genericSort(list, type, ascending)
-    manager.setRender(sortedList)
-}
-
-module.exports = {
-    doInitSort,
-    doSort,
-}
-
-},{"./datamanager.js":1,"./storage.js":8}],8:[function(require,module,exports){
-const possibleFilters = [
-    'passed',
-    'skipped',
-    'failed',
-    'error',
-    'xfailed',
-    'xpassed',
-    'rerun',
-]
-
-const getVisible = () => {
-    const url = new URL(window.location.href)
-    const settings = new URLSearchParams(url.search).get('visible')
-    const lower = (item) => {
-        const lowerItem = item.toLowerCase()
-        if (possibleFilters.includes(lowerItem)) {
-            return lowerItem
-        }
-        return null
-    }
-    return settings === null ?
-        possibleFilters :
-        [...new Set(settings?.split(',').map(lower).filter((item) => item))]
-}
-
-const hideCategory = (categoryToHide) => {
-    const url = new URL(window.location.href)
-    const visibleParams = new URLSearchParams(url.search).get('visible')
-    const currentVisible = visibleParams ? visibleParams.split(',') : [...possibleFilters]
-    const settings = [...new Set(currentVisible)].filter((f) => f !== categoryToHide).join(',')
-
-    url.searchParams.set('visible', settings)
-    window.history.pushState({}, null, unescape(url.href))
-}
-
-const showCategory = (categoryToShow) => {
-    if (typeof window === 'undefined') {
-        return
-    }
-    const url = new URL(window.location.href)
-    const currentVisible = new URLSearchParams(url.search).get('visible')?.split(',').filter(Boolean) ||
-        [...possibleFilters]
-    const settings = [...new Set([categoryToShow, ...currentVisible])]
-    const noFilter = possibleFilters.length === settings.length || !settings.length
-
-    noFilter ? url.searchParams.delete('visible') : url.searchParams.set('visible', settings.join(','))
-    window.history.pushState({}, null, unescape(url.href))
-}
-
-const getSort = (initialSort) => {
-    const url = new URL(window.location.href)
-    let sort = new URLSearchParams(url.search).get('sort')
-    if (!sort) {
-        sort = initialSort || 'result'
-    }
-    return sort
-}
-
-const setSort = (type) => {
-    const url = new URL(window.location.href)
-    url.searchParams.set('sort', type)
-    window.history.pushState({}, null, unescape(url.href))
-}
-
-const getCollapsedCategory = (renderCollapsed) => {
-    let categories
-    if (typeof window !== 'undefined') {
-        const url = new URL(window.location.href)
-        const collapsedItems = new URLSearchParams(url.search).get('collapsed')
-        switch (true) {
-        case !renderCollapsed && collapsedItems === null:
-            categories = ['passed']
-            break
-        case collapsedItems?.length === 0 || /^["']{2}$/.test(collapsedItems):
-            categories = []
-            break
-        case /^all$/.test(collapsedItems) || collapsedItems === null && /^all$/.test(renderCollapsed):
-            categories = [...possibleFilters]
-            break
-        default:
-            categories = collapsedItems?.split(',').map((item) => item.toLowerCase()) || renderCollapsed
-            break
-        }
-    } else {
-        categories = []
-    }
-    return categories
-}
-
-const getSortDirection = () => JSON.parse(sessionStorage.getItem('sortAsc')) || false
-const setSortDirection = (ascending) => sessionStorage.setItem('sortAsc', ascending)
-
-const getCollapsedIds = () => JSON.parse(sessionStorage.getItem('collapsedIds')) || []
-const setCollapsedIds = (list) => sessionStorage.setItem('collapsedIds', JSON.stringify(list))
-
-module.exports = {
-    getVisible,
-    hideCategory,
-    showCategory,
-    getCollapsedIds,
-    setCollapsedIds,
-    getSort,
-    setSort,
-    getSortDirection,
-    setSortDirection,
-    getCollapsedCategory,
-    possibleFilters,
-}
-
-},{}]},{},[4]);
+            return r
+        })()({
+            1: [function (require, module, exports) {
+                const {getCollapsedCategory, setCollapsedIds} = require('./storage.js')
+
+                class DataManager {
+                    setManager(data) {
+                        const collapsedCategories = [...getCollapsedCategory(data.renderCollapsed)]
+                        const collapsedIds = []
+                        const tests = Object.values(data.tests).flat().map((test, index) => {
+                            const collapsed = collapsedCategories.includes(test.result.toLowerCase())
+                            const id = `test_${index}`
+                            if (collapsed) {
+                                collapsedIds.push(id)
+                            }
+                            return {
+                                ...test,
+                                id,
+                                collapsed,
+                            }
+                        })
+                        const dataBlob = {...data, tests}
+                        this.data = {...dataBlob}
+                        this.renderData = {...dataBlob}
+                        setCollapsedIds(collapsedIds)
+                    }
+
+                    get allData() {
+                        return {...this.data}
+                    }
+
+                    resetRender() {
+                        this.renderData = {...this.data}
+                    }
+
+                    setRender(data) {
+                        this.renderData.tests = [...data]
+                    }
+
+                    toggleCollapsedItem(id) {
+                        this.renderData.tests = this.renderData.tests.map((test) =>
+                            test.id === id ? {...test, collapsed: !test.collapsed} : test,
+                        )
+                    }
+
+                    set allCollapsed(collapsed) {
+                        this.renderData = {
+                            ...this.renderData, tests: [...this.renderData.tests.map((test) => (
+                                {...test, collapsed}
+                            ))]
+                        }
+                    }
+
+                    get testSubset() {
+                        return [...this.renderData.tests]
+                    }
+
+                    get environment() {
+                        return this.renderData.environment
+                    }
+
+                    get initialSort() {
+                        return this.data.initialSort
+                    }
+                }
+
+                module.exports = {
+                    manager: new DataManager(),
+                }
+
+            }, {"./storage.js": 8}],
+            2: [function (require, module, exports) {
+                const mediaViewer = require('./mediaviewer.js')
+                const templateEnvRow = document.getElementById('template_environment_row')
+                const templateResult = document.getElementById('template_results-table__tbody')
+
+                function htmlToElements(html) {
+                    const temp = document.createElement('template')
+                    temp.innerHTML = html
+                    return temp.content.childNodes
+                }
+
+                const find = (selector, elem) => {
+                    if (!elem) {
+                        elem = document
+                    }
+                    return elem.querySelector(selector)
+                }
+
+                const findAll = (selector, elem) => {
+                    if (!elem) {
+                        elem = document
+                    }
+                    return [...elem.querySelectorAll(selector)]
+                }
+
+                const dom = {
+                    getStaticRow: (key, value) => {
+                        const envRow = templateEnvRow.content.cloneNode(true)
+                        const isObj = typeof value === 'object' && value !== null
+                        const values = isObj ? Object.keys(value).map((k) => `${k}: ${value[k]}`) : null
+
+                        const valuesElement = htmlToElements(
+                            values ? `<ul>${values.map((val) => `<li>${val}</li>`).join('')}<ul>` : `<div>${value}</div>`)[0]
+                        const td = findAll('td', envRow)
+                        td[0].textContent = key
+                        td[1].appendChild(valuesElement)
+
+                        return envRow
+                    },
+                    getResultTBody: ({testId, id, log, extras, resultsTableRow, tableHtml, result, collapsed}) => {
+                        const resultBody = templateResult.content.cloneNode(true)
+                        resultBody.querySelector('tbody').classList.add(result.toLowerCase())
+                        resultBody.querySelector('tbody').id = testId
+                        resultBody.querySelector('.collapsible').dataset.id = id
+
+                        resultsTableRow.forEach((html) => {
+                            const t = document.createElement('template')
+                            t.innerHTML = html
+                            resultBody.querySelector('.collapsible').appendChild(t.content)
+                        })
+
+                        if (log) {
+                            // Wrap lines starting with "E" with span.error to color those lines red
+                            const wrappedLog = log.replace(/^E.*$/gm, (match) => `<span class="error">${match}</span>`)
+                            resultBody.querySelector('.log').innerHTML = wrappedLog
+                        } else {
+                            resultBody.querySelector('.log').remove()
+                        }
+
+                        if (collapsed) {
+                            resultBody.querySelector('.collapsible > td')?.classList.add('collapsed')
+                            resultBody.querySelector('.extras-row').classList.add('hidden')
+                        } else {
+                            resultBody.querySelector('.collapsible > td')?.classList.remove('collapsed')
+                        }
+
+                        const media = []
+                        extras?.forEach(({name, format_type, content}) => {
+                            if (['image', 'video'].includes(format_type)) {
+                                media.push({path: content, name, format_type})
+                            }
+
+                            if (format_type === 'html') {
+                                resultBody.querySelector('.extraHTML').insertAdjacentHTML('beforeend', `<div>${content}</div>`)
+                            }
+                        })
+                        mediaViewer.setup(resultBody, media)
+
+                        // Add custom html from the pytest_html_results_table_html hook
+                        tableHtml?.forEach((item) => {
+                            resultBody.querySelector('td[class="extra"]').insertAdjacentHTML('beforeend', item)
+                        })
+
+                        return resultBody
+                    },
+                }
+
+                module.exports = {
+                    dom,
+                    htmlToElements,
+                    find,
+                    findAll,
+                }
+
+            }, {"./mediaviewer.js": 6}],
+            3: [function (require, module, exports) {
+                const {manager} = require('./datamanager.js')
+                const {doSort} = require('./sort.js')
+                const storageModule = require('./storage.js')
+
+                const getFilteredSubSet = (filter) =>
+                    manager.allData.tests.filter(({result}) => filter.includes(result.toLowerCase()))
+
+                const doInitFilter = () => {
+                    const currentFilter = storageModule.getVisible()
+                    const filteredSubset = getFilteredSubSet(currentFilter)
+                    manager.setRender(filteredSubset)
+                }
+
+                const doFilter = (type, show) => {
+                    if (show) {
+                        storageModule.showCategory(type)
+                    } else {
+                        storageModule.hideCategory(type)
+                    }
+
+                    const currentFilter = storageModule.getVisible()
+                    const filteredSubset = getFilteredSubSet(currentFilter)
+                    manager.setRender(filteredSubset)
+
+                    const sortColumn = storageModule.getSort()
+                    doSort(sortColumn, true)
+                }
+
+                module.exports = {
+                    doFilter,
+                    doInitFilter,
+                }
+
+            }, {"./datamanager.js": 1, "./sort.js": 7, "./storage.js": 8}],
+            4: [function (require, module, exports) {
+                const {redraw, bindEvents, renderStatic} = require('./main.js')
+                const {doInitFilter} = require('./filter.js')
+                const {doInitSort} = require('./sort.js')
+                const {manager} = require('./datamanager.js')
+                const data = JSON.parse(document.getElementById('data-container').dataset.jsonblob)
+
+                function init() {
+                    manager.setManager(data)
+                    doInitFilter()
+                    doInitSort()
+                    renderStatic()
+                    redraw()
+                    bindEvents()
+                }
+
+                init()
+
+            }, {"./datamanager.js": 1, "./filter.js": 3, "./main.js": 5, "./sort.js": 7}],
+            5: [function (require, module, exports) {
+                const {dom, find, findAll} = require('./dom.js')
+                const {manager} = require('./datamanager.js')
+                const {doSort} = require('./sort.js')
+                const {doFilter} = require('./filter.js')
+                const {
+                    getVisible,
+                    getCollapsedIds,
+                    setCollapsedIds,
+                    getSort,
+                    getSortDirection,
+                    possibleFilters,
+                } = require('./storage.js')
+
+                const removeChildren = (node) => {
+                    while (node.firstChild) {
+                        node.removeChild(node.firstChild)
+                    }
+                }
+
+                const renderStatic = () => {
+                    const renderEnvironmentTable = () => {
+                        const environment = manager.environment
+                        const rows = Object.keys(environment).map((key) => dom.getStaticRow(key, environment[key]))
+                        const table = document.getElementById('environment')
+                        removeChildren(table)
+                        rows.forEach((row) => table.appendChild(row))
+                    }
+                    renderEnvironmentTable()
+                }
+
+                const addItemToggleListener = (elem) => {
+                    elem.addEventListener('click', ({target}) => {
+                        const id = target.parentElement.dataset.id
+                        manager.toggleCollapsedItem(id)
+
+                        const collapsedIds = getCollapsedIds()
+                        if (collapsedIds.includes(id)) {
+                            const updated = collapsedIds.filter((item) => item !== id)
+                            setCollapsedIds(updated)
+                        } else {
+                            collapsedIds.push(id)
+                            setCollapsedIds(collapsedIds)
+                        }
+                        redraw()
+                    })
+                }
+
+                const renderContent = (tests) => {
+                    const sortAttr = getSort(manager.initialSort)
+                    const sortAsc = JSON.parse(getSortDirection())
+                    const rows = tests.map(dom.getResultTBody)
+                    const table = document.getElementById('results-table')
+                    const tableHeader = document.getElementById('results-table-head')
+
+                    const newTable = document.createElement('table')
+                    newTable.id = 'results-table'
+
+                    // remove all sorting classes and set the relevant
+                    findAll('.sortable', tableHeader).forEach((elem) => elem.classList.remove('asc', 'desc'))
+                    tableHeader.querySelector(`.sortable[data-column-type="${sortAttr}"]`)?.classList.add(sortAsc ? 'desc' : 'asc')
+                    newTable.appendChild(tableHeader)
+
+                    if (!rows.length) {
+                        const emptyTable = document.getElementById('template_results-table__body--empty').content.cloneNode(true)
+                        newTable.appendChild(emptyTable)
+                    } else {
+                        rows.forEach((row) => {
+                            if (!!row) {
+                                findAll('.collapsible td:not(.col-links', row).forEach(addItemToggleListener)
+                                find('.logexpander', row).addEventListener('click',
+                                    (evt) => evt.target.parentNode.classList.toggle('expanded'),
+                                )
+                                newTable.appendChild(row)
+                            }
+                        })
+                    }
+
+                    table.replaceWith(newTable)
+                }
+
+                const renderDerived = () => {
+                    const currentFilter = getVisible()
+                    possibleFilters.forEach((result) => {
+                        const input = document.querySelector(`input[data-test-result="${result}"]`)
+                        input.checked = currentFilter.includes(result)
+                    })
+                }
+
+                const bindEvents = () => {
+                    const filterColumn = (evt) => {
+                        const {target: element} = evt
+                        const {testResult} = element.dataset
+
+                        doFilter(testResult, element.checked)
+                        const collapsedIds = getCollapsedIds()
+                        const updated = manager.renderData.tests.map((test) => {
+                            return {
+                                ...test,
+                                collapsed: collapsedIds.includes(test.id),
+                            }
+                        })
+                        manager.setRender(updated)
+                        redraw()
+                    }
+
+                    const header = document.getElementById('environment-header')
+                    header.addEventListener('click', () => {
+                        const table = document.getElementById('environment')
+                        table.classList.toggle('hidden')
+                        header.classList.toggle('collapsed')
+                    })
+
+                    findAll('input[name="filter_checkbox"]').forEach((elem) => {
+                        elem.addEventListener('click', filterColumn)
+                    })
+
+                    findAll('.sortable').forEach((elem) => {
+                        elem.addEventListener('click', (evt) => {
+                            const {target: element} = evt
+                            const {columnType} = element.dataset
+                            doSort(columnType)
+                            redraw()
+                        })
+                    })
+
+                    document.getElementById('show_all_details').addEventListener('click', () => {
+                        manager.allCollapsed = false
+                        setCollapsedIds([])
+                        redraw()
+                    })
+                    document.getElementById('hide_all_details').addEventListener('click', () => {
+                        manager.allCollapsed = true
+                        const allIds = manager.renderData.tests.map((test) => test.id)
+                        setCollapsedIds(allIds)
+                        redraw()
+                    })
+                }
+
+                const redraw = () => {
+                    const {testSubset} = manager
+
+                    renderContent(testSubset)
+                    renderDerived()
+                }
+
+                module.exports = {
+                    redraw,
+                    bindEvents,
+                    renderStatic,
+                }
+
+            }, {"./datamanager.js": 1, "./dom.js": 2, "./filter.js": 3, "./sort.js": 7, "./storage.js": 8}],
+            6: [function (require, module, exports) {
+                class MediaViewer {
+                    constructor(assets) {
+                        this.assets = assets
+                        this.index = 0
+                    }
+
+                    nextActive() {
+                        this.index = this.index === this.assets.length - 1 ? 0 : this.index + 1
+                        return [this.activeFile, this.index]
+                    }
+
+                    prevActive() {
+                        this.index = this.index === 0 ? this.assets.length - 1 : this.index - 1
+                        return [this.activeFile, this.index]
+                    }
+
+                    get currentIndex() {
+                        return this.index
+                    }
+
+                    get activeFile() {
+                        return this.assets[this.index]
+                    }
+                }
+
+
+                const setup = (resultBody, assets) => {
+                    if (!assets.length) {
+                        resultBody.querySelector('.media').classList.add('hidden')
+                        return
+                    }
+
+                    const mediaViewer = new MediaViewer(assets)
+                    const container = resultBody.querySelector('.media-container')
+                    const leftArrow = resultBody.querySelector('.media-container__nav--left')
+                    const rightArrow = resultBody.querySelector('.media-container__nav--right')
+                    const mediaName = resultBody.querySelector('.media__name')
+                    const counter = resultBody.querySelector('.media__counter')
+                    const imageEl = resultBody.querySelector('img')
+                    const sourceEl = resultBody.querySelector('source')
+                    const videoEl = resultBody.querySelector('video')
+
+                    const setImg = (media, index) => {
+                        if (media?.format_type === 'image') {
+                            imageEl.src = media.path
+
+                            imageEl.classList.remove('hidden')
+                            videoEl.classList.add('hidden')
+                        } else if (media?.format_type === 'video') {
+                            sourceEl.src = media.path
+
+                            videoEl.classList.remove('hidden')
+                            imageEl.classList.add('hidden')
+                        }
+
+                        mediaName.innerText = media?.name
+                        counter.innerText = `${index + 1} / ${assets.length}`
+                    }
+                    setImg(mediaViewer.activeFile, mediaViewer.currentIndex)
+
+                    const moveLeft = () => {
+                        const [media, index] = mediaViewer.prevActive()
+                        setImg(media, index)
+                    }
+                    const doRight = () => {
+                        const [media, index] = mediaViewer.nextActive()
+                        setImg(media, index)
+                    }
+                    const openImg = () => {
+                        window.open(mediaViewer.activeFile.path, '_blank')
+                    }
+                    if (assets.length === 1) {
+                        container.classList.add('media-container--fullscreen')
+                    } else {
+                        leftArrow.addEventListener('click', moveLeft)
+                        rightArrow.addEventListener('click', doRight)
+                    }
+                    imageEl.addEventListener('click', openImg)
+                }
+
+                module.exports = {
+                    setup,
+                }
+
+            }, {}],
+            7: [function (require, module, exports) {
+                const {manager} = require('./datamanager.js')
+                const storageModule = require('./storage.js')
+
+                const genericSort = (list, key, ascending, customOrder) => {
+                    let sorted
+                    if (customOrder) {
+                        sorted = list.sort((a, b) => {
+                            const aValue = a.result.toLowerCase()
+                            const bValue = b.result.toLowerCase()
+
+                            const aIndex = customOrder.findIndex((item) => item.toLowerCase() === aValue)
+                            const bIndex = customOrder.findIndex((item) => item.toLowerCase() === bValue)
+
+                            // Compare the indices to determine the sort order
+                            return aIndex - bIndex
+                        })
+                    } else {
+                        sorted = list.sort((a, b) => a[key] === b[key] ? 0 : a[key] > b[key] ? 1 : -1)
+                    }
+
+                    if (ascending) {
+                        sorted.reverse()
+                    }
+                    return sorted
+                }
+
+                const durationSort = (list, ascending) => {
+                    const parseDuration = (duration) => {
+                        if (duration.includes(':')) {
+                            // If it's in the format "HH:mm:ss"
+                            const [hours, minutes, seconds] = duration.split(':').map(Number)
+                            return (hours * 3600 + minutes * 60 + seconds) * 1000
+                        } else {
+                            // If it's in the format "nnn ms"
+                            return parseInt(duration)
+                        }
+                    }
+                    const sorted = list.sort((a, b) => parseDuration(a['duration']) - parseDuration(b['duration']))
+                    if (ascending) {
+                        sorted.reverse()
+                    }
+                    return sorted
+                }
+
+                const doInitSort = () => {
+                    const type = storageModule.getSort(manager.initialSort)
+                    const ascending = storageModule.getSortDirection()
+                    const list = manager.testSubset
+                    const initialOrder = ['Error', 'Failed', 'Rerun', 'XFailed', 'XPassed', 'Skipped', 'Passed']
+
+                    storageModule.setSort(type)
+                    storageModule.setSortDirection(ascending)
+
+                    if (type?.toLowerCase() === 'original') {
+                        manager.setRender(list)
+                    } else {
+                        let sortedList
+                        switch (type) {
+                            case 'duration':
+                                sortedList = durationSort(list, ascending)
+                                break
+                            case 'result':
+                                sortedList = genericSort(list, type, ascending, initialOrder)
+                                break
+                            default:
+                                sortedList = genericSort(list, type, ascending)
+                                break
+                        }
+                        manager.setRender(sortedList)
+                    }
+                }
+
+                const doSort = (type, skipDirection) => {
+                    const newSortType = storageModule.getSort(manager.initialSort) !== type
+                    const currentAsc = storageModule.getSortDirection()
+                    let ascending
+                    if (skipDirection) {
+                        ascending = currentAsc
+                    } else {
+                        ascending = newSortType ? false : !currentAsc
+                    }
+                    storageModule.setSort(type)
+                    storageModule.setSortDirection(ascending)
+
+                    const list = manager.testSubset
+                    const sortedList = type === 'duration' ? durationSort(list, ascending) : genericSort(list, type, ascending)
+                    manager.setRender(sortedList)
+                }
+
+                module.exports = {
+                    doInitSort,
+                    doSort,
+                }
+
+            }, {"./datamanager.js": 1, "./storage.js": 8}],
+            8: [function (require, module, exports) {
+                const possibleFilters = [
+                    'passed',
+                    'skipped',
+                    'failed',
+                    'error',
+                    'xfailed',
+                    'xpassed',
+                    'rerun',
+                ]
+
+                const getVisible = () => {
+                    const url = new URL(window.location.href)
+                    const settings = new URLSearchParams(url.search).get('visible')
+                    const lower = (item) => {
+                        const lowerItem = item.toLowerCase()
+                        if (possibleFilters.includes(lowerItem)) {
+                            return lowerItem
+                        }
+                        return null
+                    }
+                    return settings === null ?
+                        possibleFilters :
+                        [...new Set(settings?.split(',').map(lower).filter((item) => item))]
+                }
+
+                const hideCategory = (categoryToHide) => {
+                    const url = new URL(window.location.href)
+                    const visibleParams = new URLSearchParams(url.search).get('visible')
+                    const currentVisible = visibleParams ? visibleParams.split(',') : [...possibleFilters]
+                    const settings = [...new Set(currentVisible)].filter((f) => f !== categoryToHide).join(',')
+
+                    url.searchParams.set('visible', settings)
+                    window.history.pushState({}, null, unescape(url.href))
+                }
+
+                const showCategory = (categoryToShow) => {
+                    if (typeof window === 'undefined') {
+                        return
+                    }
+                    const url = new URL(window.location.href)
+                    const currentVisible = new URLSearchParams(url.search).get('visible')?.split(',').filter(Boolean) ||
+                        [...possibleFilters]
+                    const settings = [...new Set([categoryToShow, ...currentVisible])]
+                    const noFilter = possibleFilters.length === settings.length || !settings.length
+
+                    noFilter ? url.searchParams.delete('visible') : url.searchParams.set('visible', settings.join(','))
+                    window.history.pushState({}, null, unescape(url.href))
+                }
+
+                const getSort = (initialSort) => {
+                    const url = new URL(window.location.href)
+                    let sort = new URLSearchParams(url.search).get('sort')
+                    if (!sort) {
+                        sort = initialSort || 'result'
+                    }
+                    return sort
+                }
+
+                const setSort = (type) => {
+                    const url = new URL(window.location.href)
+                    url.searchParams.set('sort', type)
+                    window.history.pushState({}, null, unescape(url.href))
+                }
+
+                const getCollapsedCategory = (renderCollapsed) => {
+                    let categories
+                    if (typeof window !== 'undefined') {
+                        const url = new URL(window.location.href)
+                        const collapsedItems = new URLSearchParams(url.search).get('collapsed')
+                        switch (true) {
+                            case !renderCollapsed && collapsedItems === null:
+                                categories = ['passed']
+                                break
+                            case collapsedItems?.length === 0 || /^["']{2}$/.test(collapsedItems):
+                                categories = []
+                                break
+                            case /^all$/.test(collapsedItems) || collapsedItems === null && /^all$/.test(renderCollapsed):
+                                categories = [...possibleFilters]
+                                break
+                            default:
+                                categories = collapsedItems?.split(',').map((item) => item.toLowerCase()) || renderCollapsed
+                                break
+                        }
+                    } else {
+                        categories = []
+                    }
+                    return categories
+                }
+
+                const getSortDirection = () => JSON.parse(sessionStorage.getItem('sortAsc')) || false
+                const setSortDirection = (ascending) => sessionStorage.setItem('sortAsc', ascending)
+
+                const getCollapsedIds = () => JSON.parse(sessionStorage.getItem('collapsedIds')) || []
+                const setCollapsedIds = (list) => sessionStorage.setItem('collapsedIds', JSON.stringify(list))
+
+                module.exports = {
+                    getVisible,
+                    hideCategory,
+                    showCategory,
+                    getCollapsedIds,
+                    setCollapsedIds,
+                    getSort,
+                    setSort,
+                    getSortDirection,
+                    setSortDirection,
+                    getCollapsedCategory,
+                    possibleFilters,
+                }
+
+            }, {}]
+        }, {}, [4]);
     </script>
-  </footer>
+</footer>
 </html>


### PR DESCRIPTION
Consider automatic use case / rule set, and respective test case generation from these changes!

I just applied a code reformatting by the already implemented JetBrains IntelliJ plugin of @ahus1 to make the docs better readable and maintainable. OK, to be honest, I changed the MarkDown format of ADRs manually to proper AsciiDoc 😎.