### PR TITLE
Fix section title blank line errors in README.adoc

### DIFF
--- a/asciidoc_linter/rules/whitespace_rules.py
+++ b/asciidoc_linter/rules/whitespace_rules.py
@@ -121,7 +121,7 @@ class WhitespaceRule(Rule):
             # Check for blank line before section title (except for first line)
             if line_number > 0:
                 prev_content = self.get_line_content(context[line_number - 1])
-                if prev_content.strip():
+                if prev_content.strip() and not prev_content.strip().startswith(("[.", "[[")):
                     findings.append(
                         Finding(
                             rule_id=self.id,
@@ -135,7 +135,7 @@ class WhitespaceRule(Rule):
             # Check for blank line after section title (except for last line)
             if line_number < len(context) - 1:
                 next_content = self.get_line_content(context[line_number + 1])
-                if next_content.strip():
+                if next_content.strip() and not next_content.strip().startswith(":"):
                     findings.append(
                         Finding(
                             rule_id=self.id,

--- a/tests/rules/test_heading_rules.py
+++ b/tests/rules/test_heading_rules.py
@@ -308,5 +308,61 @@ class TestMultipleTopLevelHeadingsRule(unittest.TestCase):
         )
 
 
+class TestHeadingAttributesAndRoles(unittest.TestCase):
+    """Tests for headings with attributes or roles.
+    This rule ensures that headings followed by attributes or roles are handled correctly.
+    """
+
+    def setUp(self):
+        """
+        Given a HeadingFormatRule instance
+        """
+        self.rule = HeadingFormatRule()
+
+    def test_heading_with_attribute(self):
+        """
+        Given a document with headings followed by attributes
+        When the heading format rule is checked
+        Then no findings should be reported
+        """
+        # Given: A document with headings followed by attributes
+        content = """
+= Level 1
+:attribute: value
+
+== Level 2
+:another-attribute: value
+"""
+        # When: We check the heading format
+        findings = self.rule.check(content)
+
+        # Then: No findings should be reported
+        self.assertEqual(
+            len(findings), 0, "Headings followed by attributes should not produce findings"
+        )
+
+    def test_heading_with_role(self):
+        """
+        Given a document with headings followed by roles
+        When the heading format rule is checked
+        Then no findings should be reported
+        """
+        # Given: A document with headings followed by roles
+        content = """
+[.role]
+= Level 1
+
+[[target]]
+== Level 2
+"""
+        # When: We check the heading format
+        findings = self.rule.check(content)
+
+        # Then: No findings should be reported
+        self.assertEqual(
+            len(findings), 0, "Headings followed by roles should not produce findings"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -184,3 +184,27 @@ rules:
 
     # Ensure that the WS001 rule is disabled and no findings are reported
     assert len(report.findings) == 0
+
+
+def test_lint_string_with_attributes_and_roles(mock_parser, mock_rule):
+    """Test linting a string with headings followed by attributes or roles"""
+    content = """
+= Title
+:attribute: value
+
+[.role]
+== Section 1
+
+[[target]]
+== Section 2
+"""
+
+    with patch("asciidoc_linter.linter.AsciiDocParser", return_value=mock_parser):
+        linter = AsciiDocLinter()
+        linter.rules = [mock_rule]
+
+        findings = linter.lint_string(content)
+
+        assert len(findings) == 0
+        mock_parser.parse.assert_called_once_with(content)
+        mock_rule.check.assert_called_once()

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -171,3 +171,29 @@ def test_html_reporter_styling(sample_report):
     assert "<style>" in output
     assert "table {" in output
     assert "border-collapse: collapse" in output
+
+
+def test_console_reporter_with_attributes_and_roles():
+    """Test formatting errors with headings followed by attributes or roles"""
+    findings = [
+        Finding(
+            message="Section title should be followed by a blank line",
+            severity=Severity.WARNING,
+            file="test.adoc",
+            position=Position(line=2),
+            rule_id="WS001",
+        ),
+        Finding(
+            message="Section title should be preceded by a blank line",
+            severity=Severity.WARNING,
+            file="test.adoc",
+            position=Position(line=4),
+            rule_id="WS001",
+        ),
+    ]
+    report = LintReport(findings)
+    reporter = ConsoleReporter(enable_color=False)
+    lines = reporter.format_report(report).split("\n")
+    assert "Results for test.adoc:" in lines
+    assert "✗ test.adoc, line 2: Section title should be followed by a blank line" in lines
+    assert "✗ test.adoc, line 4: Section title should be preceded by a blank line" in lines


### PR DESCRIPTION
Related to #18

Fix the self_test_readme action to pass without false positives for section title blank line errors in `README.adoc`.

* **Update `asciidoc_linter/rules/whitespace_rules.py`**:
  - Modify `WhitespaceRule` to account for attributes or roles after section titles.
  - Update `check_line` method to handle attributes and roles correctly.

* **Add tests in `tests/rules/test_heading_rules.py`**:
  - Add tests for headings followed by attributes.
  - Add tests for headings followed by roles.

* **Add test cases in `tests/test_linter.py`**:
  - Add test cases for headings followed by attributes or roles.

* **Add test cases in `tests/test_reporter.py`**:
  - Add test cases for formatting errors with headings followed by attributes or roles.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/docToolchain/asciidoc-linter/issues/18?shareId=XXXX-XXXX-XXXX-XXXX).