### PR TITLE
Fix failing test in README.adoc

### DIFF
--- a/asciidoc_linter/rules/whitespace_rules.py
+++ b/asciidoc_linter/rules/whitespace_rules.py
@@ -121,7 +121,7 @@ class WhitespaceRule(Rule):
             # Check for blank line before section title (except for first line)
             if line_number > 0:
                 prev_content = self.get_line_content(context[line_number - 1])
-                if prev_content.strip():
+                if prev_content.strip() and not prev_content.strip().startswith(("[.", "[[")):
                     findings.append(
                         Finding(
                             rule_id=self.id,
@@ -135,7 +135,7 @@ class WhitespaceRule(Rule):
             # Check for blank line after section title (except for last line)
             if line_number < len(context) - 1:
                 next_content = self.get_line_content(context[line_number + 1])
-                if next_content.strip():
+                if next_content.strip() and not next_content.strip().startswith(":"):
                     findings.append(
                         Finding(
                             rule_id=self.id,

--- a/tests/rules/test_heading_rules.py
+++ b/tests/rules/test_heading_rules.py
@@ -308,5 +308,61 @@ class TestMultipleTopLevelHeadingsRule(unittest.TestCase):
         )
 
 
+class TestHeadingAttributesAndRoles(unittest.TestCase):
+    """Tests for headings with attributes and roles.
+    This rule ensures that headings with attributes and roles are properly handled.
+    """
+
+    def setUp(self):
+        """
+        Given a HeadingFormatRule instance
+        """
+        self.rule = HeadingFormatRule()
+
+    def test_heading_with_attributes(self):
+        """
+        Given a document with headings followed by attributes
+        When the heading format rule is checked
+        Then no findings should be reported
+        """
+        # Given: A document with headings followed by attributes
+        content = """
+= Level 1
+:attribute: value
+
+== Level 2
+:another-attribute: value
+"""
+        # When: We check the heading format
+        findings = self.rule.check(content)
+
+        # Then: No findings should be reported
+        self.assertEqual(
+            len(findings), 0, "Headings followed by attributes should not produce findings"
+        )
+
+    def test_heading_with_roles(self):
+        """
+        Given a document with headings preceded by roles
+        When the heading format rule is checked
+        Then no findings should be reported
+        """
+        # Given: A document with headings preceded by roles
+        content = """
+[.role]
+= Level 1
+
+[[target]]
+== Level 2
+"""
+        # When: We check the heading format
+        findings = self.rule.check(content)
+
+        # Then: No findings should be reported
+        self.assertEqual(
+            len(findings), 0, "Headings preceded by roles should not produce findings"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Related to #18

Update `WhitespaceRule` to account for attributes and roles around section titles.

* Modify `check_line` method in `asciidoc_linter/rules/whitespace_rules.py` to handle attributes and roles.
* Add tests in `tests/rules/test_heading_rules.py` for attributes and roles around section titles.
  * Include tests for headings followed by attributes.
  * Include tests for headings preceded by roles.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/docToolchain/asciidoc-linter/issues/18?shareId=XXXX-XXXX-XXXX-XXXX).