### PR TITLE
Fix failing test in README.adoc

### DIFF
--- a/asciidoc_linter/rules/whitespace_rules.py
+++ b/asciidoc_linter/rules/whitespace_rules.py
@@ -121,7 +121,7 @@ class WhitespaceRule(Rule):
             # Check for blank line before section title (except for first line)
             if line_number > 0:
                 prev_content = self.get_line_content(context[line_number - 1])
-                if prev_content.strip():
+                if prev_content.strip() and not prev_content.strip().startswith(("[.", "[[")):
                     findings.append(
                         Finding(
                             rule_id=self.id,
@@ -135,7 +135,7 @@ class WhitespaceRule(Rule):
             # Check for blank line after section title (except for last line)
             if line_number < len(context) - 1:
                 next_content = self.get_line_content(context[line_number + 1])
-                if next_content.strip():
+                if next_content.strip() and not next_content.strip().startswith(":"):
                     findings.append(
                         Finding(
                             rule_id=self.id,

--- a/tests/rules/test_heading_rules.py
+++ b/tests/rules/test_heading_rules.py
@@ -308,5 +308,60 @@ class TestMultipleTopLevelHeadingsRule(unittest.TestCase):
         )
 
 
+class TestHeadingAttributesAndRoles(unittest.TestCase):
+    """Tests for handling attributes and roles around section titles."""
+
+    def setUp(self):
+        """
+        Given a WhitespaceRule instance
+        """
+        from asciidoc_linter.rules.whitespace_rules import WhitespaceRule
+        self.rule = WhitespaceRule()
+
+    def test_attributes_after_heading(self):
+        """
+        Given a document with attributes immediately after headings
+        When the whitespace rule is checked
+        Then no findings should be reported
+        """
+        # Given: A document with attributes after headings
+        content = """
+= Title
+:attribute: value
+
+== Section
+:another-attribute: value
+"""
+        # When: We check the document
+        findings = self.rule.check(content)
+
+        # Then: No findings should be reported
+        self.assertEqual(
+            len(findings), 0, "Attributes after headings should not produce findings"
+        )
+
+    def test_roles_before_heading(self):
+        """
+        Given a document with roles immediately before headings
+        When the whitespace rule is checked
+        Then no findings should be reported
+        """
+        # Given: A document with roles before headings
+        content = """
+[.role]
+= Title
+
+[[target]]
+== Section
+"""
+        # When: We check the document
+        findings = self.rule.check(content)
+
+        # Then: No findings should be reported
+        self.assertEqual(
+            len(findings), 0, "Roles before headings should not produce findings"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Related to #18

Update `WhitespaceRule` to account for attributes and roles around section titles.

* Modify `check_line` method in `asciidoc_linter/rules/whitespace_rules.py` to handle attributes and roles.
* Add tests in `tests/rules/test_heading_rules.py` for attributes and roles around section titles.
* Ensure tests cover both attributes and roles before and after section titles.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/docToolchain/asciidoc-linter/issues/18?shareId=XXXX-XXXX-XXXX-XXXX).