### PR TITLE
Fix UTF-8 encoding for file reads (Issue #24)

### DIFF
--- a/asciidoc_linter/linter.py
+++ b/asciidoc_linter/linter.py
@@ -53,7 +53,7 @@ class AsciiDocLinter:
     def load_config(self, config_path: str) -> None:
         """Load configuration from a YAML file"""
         try:
-            with open(config_path, "r") as config_file:
+            with open(config_path, "r", encoding="utf-8") as config_file:
                 config = yaml.safe_load(config_file)
                 self.apply_config(config)
         except Exception as e:
@@ -74,7 +74,9 @@ class AsciiDocLinter:
         try:
             return [
                 finding.set_file(str(file_path))
-                for finding in self.lint_string(Path(file_path).read_text())
+                for finding in self.lint_string(
+                    Path(file_path).read_text(encoding="utf-8")
+                )
             ]
         except Exception as e:
             return [

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author="Your Name",
     author_email="your.email@example.com",
     description="A linter for AsciiDoc files",
-    long_description=open("README.adoc").read(),
+    long_description=open("README.adoc", encoding="utf-8").read(),
     long_description_content_type="text/x-asciidoc",
     keywords="asciidoc, linter, documentation",
     url="https://github.com/yourusername/asciidoc-linter",


### PR DESCRIPTION
## Summary

- Fix 'charmap' codec error on Windows by adding explicit `encoding='utf-8'` to all file read operations
- Affects `linter.py:lint_file()`, `linter.py:load_config()`, and `setup.py`
- Added comprehensive tests for UTF-8 support and error handling

## Root Cause

On Windows, Python's default encoding is `cp1252` (Windows-1252), not UTF-8. When reading files with UTF-8 characters outside the cp1252 range (e.g., emojis, Chinese, Russian text), this causes:

```
Error linting file: 'charmap' codec can't decode byte 0x98 in position 2348: character maps to <undefined>
```

## Changes

| File | Change |
|------|--------|
| `asciidoc_linter/linter.py` | Added `encoding="utf-8"` to `Path.read_text()` and `open()` |
| `setup.py` | Added `encoding="utf-8"` to `open()` for README.adoc |
| `tests/test_linter.py` | Added 5 new tests for UTF-8 encoding |

## Test Plan

- [x] `test_lint_file_utf8_characters`: UTF-8 files with umlauts, emojis, Japanese, Chinese, Russian
- [x] `test_lint_file_utf8_config`: Config files with UTF-8 content
- [x] `test_lint_file_invalid_utf8_gives_error`: Error handling for non-UTF-8 files
- [x] `test_lint_file_uses_explicit_utf8_encoding`: Verify explicit encoding is used
- [x] `test_load_config_uses_explicit_utf8_encoding`: Verify config loading uses UTF-8
- [x] All 138 tests pass
- [x] Black + Flake8 clean

Closes #24

🤖 Generated with [Claude Code](https://claude.ai/code)