### PR TITLE
Update documentation for FMT001-FMT004 rules

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -68,13 +68,32 @@ This project is part of docToolchain (https://doctoolchain.org), a collection of
 |Table formatting consistency
 |WARNING/ERROR
 |⚠️ Beta
+
+|FMT001
+|Detect explicit numbered lists (1., 2., etc.) instead of AsciiDoc dot-syntax
+|WARNING
+|✅ Stable
+
+|FMT002
+|Detect non-semantic definition list patterns (*Term*: instead of Term::)
+|WARNING
+|✅ Stable
+
+|FMT003
+|Detect counter syntax in section titles ({counter:...})
+|WARNING
+|✅ Stable
+
+|FMT004
+|Detect Markdown syntax in AsciiDoc files (headings, links, images, code blocks)
+|WARNING
+|✅ Stable
 |===
 
 === Planned Rules
 
 * TABLE002: Table content validation
 * LINK001: Broken internal references
-* FMT001: Markdown-compatible styles detection
 
 == Installation
 
@@ -197,12 +216,10 @@ jobs:
 
 === Current Status
 
-* Test Coverage: 94%
-* Test Success Rate: 100% (127/127 tests passing)
+* Test Coverage: 95%
+* Test Success Rate: 100% (216/216 tests passing)
 * Known Issues:
 ** Table content validation needs improvement
-** Rules.py requires test coverage
-** Reporter module needs additional tests
 
 === Running Tests
 
@@ -234,6 +251,7 @@ asciidoc-linter/
 │       ├── base.py
 │       ├── base_rules.py
 │       ├── block_rules.py
+│       ├── format_rules.py
 │       ├── heading_rules.py
 │       ├── image_rules.py
 │       ├── table_rules.py
@@ -246,6 +264,7 @@ asciidoc-linter/
 │   ├── test_reporter.py
 │   └── rules/
 │       ├── test_block_rules.py
+│       ├── test_format_rules.py
 │       ├── test_heading_rules.py
 │       ├── test_image_rules.py
 │       ├── test_table_rules.py
@@ -300,7 +319,7 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 * 🔲 Fix table content validation
 * 🔲 Improve test coverage
 * 🔲 Add link checking
-* 🔲 Add format rules
+* ✅ Add format rules (FMT001-FMT004)
 
 === Phase 3 (Future)
 

--- a/docs/requirements.adoc
+++ b/docs/requirements.adoc
@@ -76,6 +76,29 @@ This document describes the requirements for the AsciiDoc Linter, focusing on th
 |✅ Implemented
 |===
 
+=== Format Rules
+
+[cols="1,2,1"]
+|===
+|Rule ID |Description |Status
+
+|FMT001
+|Detect explicit numbered lists (1., 2., etc.) and suggest AsciiDoc dot-syntax
+|✅ Implemented
+
+|FMT002
+|Detect non-semantic definition list patterns (*Term*: instead of Term::)
+|✅ Implemented
+
+|FMT003
+|Detect counter syntax in section titles ({counter:...})
+|✅ Implemented
+
+|FMT004
+|Detect Markdown syntax in AsciiDoc files (headings, links, images, code blocks, blockquotes)
+|✅ Implemented
+|===
+
 == Planned Rules
 
 === Table Rules
@@ -95,25 +118,6 @@ This document describes the requirements for the AsciiDoc Linter, focusing on th
 |TABLE003
 |Validate table structure (column count consistency)
 |High
-|===
-
-=== Format Rules
-
-[cols="1,2,1"]
-|===
-|Rule ID |Description |Priority
-
-|FMT001
-|Detect Markdown-compatible styles that should be AsciiDoc syntax
-|Medium
-
-|FMT002
-|Check for consistent list marker usage
-|Low
-
-|FMT003
-|Verify consistent code block syntax
-|Medium
 |===
 
 === Link Rules
@@ -139,8 +143,8 @@ The rules are organized into the following categories:
 * Block Rules: AsciiDoc block elements
 * Whitespace Rules: Spacing and layout
 * Image Rules: Image attributes and references
+* Format Rules: LLM-generated formatting issues (Markdown syntax, numbered lists, etc.)
 * Table Rules (planned): Table formatting and content
-* Format Rules (planned): General formatting concerns
 * Link Rules (planned): References and links
 
 == Implementation Phases
@@ -154,8 +158,8 @@ The rules are organized into the following categories:
 
 === Phase 2 - Enhancement Rules (Current)
 
-* 🔲 Table validation (TABLE001, TABLE002, TABLE003)
-* 🔲 Format rules (FMT001, FMT002, FMT003)
+* ⚠️ Table validation (TABLE001 implemented, TABLE002/003 planned)
+* ✅ Format rules (FMT001, FMT002, FMT003, FMT004)
 * 🔲 Link validation (LINK001, LINK002)
 
 === Phase 3 - Polish Rules (Planned)


### PR DESCRIPTION
## Summary
Updates documentation to reflect the newly implemented format rules (FMT001-FMT004).

## Changes

### README.adoc
- Added FMT001, FMT002, FMT003, FMT004 to Implemented Rules table
- Removed FMT001 from Planned Rules (now implemented)
- Updated test statistics (216 tests, 95% coverage)
- Added `format_rules.py` to project structure
- Added `test_format_rules.py` to test structure
- Marked "Add format rules" as complete in Phase 2 roadmap

### docs/requirements.adoc
- Added new Format Rules section with all 4 implemented rules
- Removed Format Rules from Planned section
- Updated Rule Categories to reflect Format Rules as implemented
- Updated Implementation Phases status

## Test plan
- [x] Linter passes on README.adoc
- [x] Linter passes on docs/requirements.adoc
- [x] All 216 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)